### PR TITLE
Update BGSC chart to use BGSCUSDT.P symbol

### DIFF
--- a/src/components/MarketOverview.tsx
+++ b/src/components/MarketOverview.tsx
@@ -71,7 +71,7 @@ const assets: AssetConfig[] = [
     id: 'bgsc',
     title: '벅스 (BGSC) 선물',
     subtitle: 'BGSC 페르페추얼 스왑 (15분 봉 기본)',
-    chartSymbol: 'BINGX:BGSCUSDT.P',
+    chartSymbol: 'BGSCUSDT.P',
     tags: ['코인 선물', '파생상품'],
   },
 ]

--- a/src/components/TradingViewChart.tsx
+++ b/src/components/TradingViewChart.tsx
@@ -14,7 +14,8 @@ const TradingViewChart = ({ symbol, interval = '15', theme = 'dark' }: TradingVi
       return
     }
 
-    containerRef.current.innerHTML = ''
+    const container = containerRef.current
+    container.innerHTML = ''
 
     const script = document.createElement('script')
     script.src = 'https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js'
@@ -38,12 +39,10 @@ const TradingViewChart = ({ symbol, interval = '15', theme = 'dark' }: TradingVi
       support_host: 'https://www.tradingview.com',
     })
 
-    containerRef.current.appendChild(script)
+    container.appendChild(script)
 
     return () => {
-      if (containerRef.current) {
-        containerRef.current.innerHTML = ''
-      }
+      container.innerHTML = ''
     }
   }, [symbol, interval, theme])
 


### PR DESCRIPTION
## Summary
- switch the BGSC market card to use the TradingView symbol `BGSCUSDT.P`
- tidy the TradingView chart cleanup handler to avoid stale ref access warnings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0dd202cd88326a4504555da4eb1d6