### PR TITLE
Fetch BGSC price from Gate.io and improve news feed

### DIFF
--- a/src/components/TradingViewChart.tsx
+++ b/src/components/TradingViewChart.tsx
@@ -10,11 +10,12 @@ const TradingViewChart = ({ symbol, interval = '15', theme = 'dark' }: TradingVi
   const containerRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
-    if (!containerRef.current) {
+    const container = containerRef.current
+    if (!container) {
       return
     }
 
-    containerRef.current.innerHTML = ''
+    container.innerHTML = ''
 
     const script = document.createElement('script')
     script.src = 'https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js'
@@ -38,12 +39,10 @@ const TradingViewChart = ({ symbol, interval = '15', theme = 'dark' }: TradingVi
       support_host: 'https://www.tradingview.com',
     })
 
-    containerRef.current.appendChild(script)
+    container.appendChild(script)
 
     return () => {
-      if (containerRef.current) {
-        containerRef.current.innerHTML = ''
-      }
+      container.innerHTML = ''
     }
   }, [symbol, interval, theme])
 


### PR DESCRIPTION
## Summary
- fetch BGSC perpetual price data from Gate.io alongside existing Yahoo and Binance quotes
- add Financial Modeling Prep as the primary news source with Alpha Vantage fallback and better date parsing
- clean up the TradingView widget effect to satisfy lint and avoid stale refs

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0df2b70888326af30ffebd7f16b2e