### PR TITLE
Update BGSC TradingView symbol

### DIFF
--- a/src/components/MarketOverview.tsx
+++ b/src/components/MarketOverview.tsx
@@ -71,7 +71,7 @@ const assets: AssetConfig[] = [
     id: 'bgsc',
     title: '벅스 (BGSC) 선물',
     subtitle: 'BGSC 페르페추얼 스왑 (15분 봉 기본)',
-    chartSymbol: 'BINGX:BGSCUSDT.P',
+    chartSymbol: 'GATEIO:BGSCUSDT.P',
     priceSource: { provider: 'gateio', symbol: 'BGSC_USDT' },
     tags: ['코인 선물', '파생상품'],
   },


### PR DESCRIPTION
## Summary
- point the BGSC perpetual chart to the GATEIO:BGSCUSDT.P symbol so the widget loads correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0e5568f1083269ad1b6e320e24a5a