### PR TITLE
feat: replace market error banner with performance summary

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -104,6 +104,63 @@
   font-size: 0.95rem;
 }
 
+.market-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+  padding: 1rem 1.1rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(71, 85, 105, 0.35);
+}
+
+.market-summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 12px;
+  background: rgba(30, 41, 59, 0.6);
+  border: 1px solid rgba(71, 85, 105, 0.4);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.market-summary-name {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.market-summary-metrics {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.market-summary-price {
+  color: rgba(226, 232, 240, 0.7);
+  font-size: 0.85rem;
+}
+
+.market-summary-change {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.market-summary-item.up .market-summary-change {
+  color: #4ade80;
+}
+
+.market-summary-item.down .market-summary-change {
+  color: #f87171;
+}
+
+.market-summary-item.neutral .market-summary-change {
+  color: rgba(226, 232, 240, 0.6);
+}
+
 .segmented-control {
   display: inline-flex;
   border-radius: 999px;

--- a/src/components/MarketOverview.tsx
+++ b/src/components/MarketOverview.tsx
@@ -176,6 +176,9 @@ const MarketOverview = () => {
     return `${sign}${formatted}%`
   }
 
+  const fallbackLabel =
+    status === 'loading' ? '불러오는 중' : status === 'error' ? '수신 실패' : '데이터 없음'
+
   return (
     <section className="section" aria-labelledby="market-overview-heading">
       <div className="section-header">
@@ -185,11 +188,28 @@ const MarketOverview = () => {
         </div>
       </div>
 
-      {status === 'error' && (
-        <div className="status-banner" role="alert">
-          가격 정보를 불러오는 중 문제가 발생했습니다. 네트워크 상태를 확인해주세요.
-        </div>
-      )}
+      <div className="market-summary" aria-live="polite">
+        {assets.map((asset) => {
+          const price = prices[asset.id]?.price ?? null
+          const changePercent = prices[asset.id]?.changePercent ?? null
+          const changeLabel = formatChange(changePercent)
+          const summaryPriceLabel =
+            price !== null ? formatPrice(price, asset.formatOptions) : fallbackLabel
+          const summaryChangeLabel = changeLabel ?? fallbackLabel
+          const summaryState =
+            changePercent === null ? 'neutral' : changePercent >= 0 ? 'up' : 'down'
+
+          return (
+            <div className={`market-summary-item ${summaryState}`} key={asset.id}>
+              <span className="market-summary-name">{asset.title}</span>
+              <div className="market-summary-metrics">
+                <span className="market-summary-price">{summaryPriceLabel}</span>
+                <span className="market-summary-change">{summaryChangeLabel}</span>
+              </div>
+            </div>
+          )
+        })}
+      </div>
 
       <div className="chart-grid">
         {assets.map((asset) => {


### PR DESCRIPTION
## Summary
- remove the network error banner that previously appeared under the market overview heading
- surface a live summary for each tracked index/coin showing the latest price and change direction
- style the summary grid with color-coded badges to highlight gains and losses at a glance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0f1376dd083269bbd33b68f594da7