### PR TITLE
Improve market overview layout and data sources

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -106,20 +106,21 @@
 
 .market-summary {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
   margin-bottom: 1.5rem;
-  padding: 1.1rem 1.2rem;
+  padding: 0.95rem 1.1rem;
   border-radius: 16px;
   background: rgba(15, 23, 42, 0.55);
   border: 1px solid rgba(71, 85, 105, 0.35);
 }
 
 .market-summary-item {
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-  padding: 0.6rem 0.75rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.35rem 0.5rem;
+  padding: 0.55rem 0.7rem;
   border-radius: 12px;
   background: rgba(30, 41, 59, 0.6);
   border: 1px solid rgba(71, 85, 105, 0.4);
@@ -128,35 +129,42 @@
 }
 
 .market-summary-name {
-  font-size: 0.9rem;
+  font-size: 0.82rem;
   font-weight: 600;
   color: #e2e8f0;
+  line-height: 1.3;
 }
 
 .market-summary-metrics {
   display: flex;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: 0.35rem 0.6rem;
-  font-size: 0.9rem;
-  line-height: 1.4;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  line-height: 1.2;
+  white-space: nowrap;
+  min-width: 0;
 }
 
-.market-summary-price,
-.market-summary-change,
 .market-summary-name {
   white-space: normal;
   word-break: keep-all;
 }
 
+.market-summary-price,
+.market-summary-change {
+  white-space: nowrap;
+  word-break: keep-all;
+}
+
 .market-summary-price {
   color: rgba(226, 232, 240, 0.7);
-  font-size: 0.85rem;
+  font-size: 0.82rem;
 }
 
 .market-summary-change {
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 0.88rem;
 }
 
 .market-summary-item.up .market-summary-change {
@@ -169,6 +177,16 @@
 
 .market-summary-item.neutral .market-summary-change {
   color: rgba(226, 232, 240, 0.6);
+}
+
+@media (min-width: 1100px) {
+  .market-summary {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .market-summary-item {
+    padding: 0.55rem 0.85rem;
+  }
 }
 
 .segmented-control {
@@ -262,8 +280,8 @@
 
 .chart-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
 }
 
 .chart-card {
@@ -273,7 +291,7 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  min-height: 420px;
+  min-height: 400px;
 }
 
 .chart-card-header {
@@ -406,6 +424,34 @@
 
   .section {
     padding: 1.5rem 1.6rem;
+  }
+
+  .market-summary {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    padding: 0.9rem 1rem;
+    gap: 0.65rem;
+  }
+
+  .market-summary-item {
+    grid-template-columns: 1fr;
+    justify-items: flex-start;
+    text-align: left;
+  }
+
+  .market-summary-metrics {
+    justify-content: flex-start;
+  }
+
+  .market-summary-name {
+    font-size: 0.78rem;
+  }
+
+  .market-summary-price {
+    font-size: 0.78rem;
+  }
+
+  .market-summary-change {
+    font-size: 0.82rem;
   }
 
   .calendar-table {

--- a/src/utils/proxyFetch.ts
+++ b/src/utils/proxyFetch.ts
@@ -1,0 +1,158 @@
+const disabledProxyValues = new Set(['0', 'false', 'off', 'none', 'no', 'direct'])
+
+type ProxyStrategy = {
+  id: string
+  build: (url: URL) => string
+}
+
+const directStrategy: ProxyStrategy = {
+  id: 'direct',
+  build: (url) => url.toString(),
+}
+
+const createStrategyFromTemplate = (template: string, id?: string): ProxyStrategy => {
+  const trimmed = template.trim()
+  const identifier = id ?? `proxy:${trimmed}`
+
+  if (!trimmed) {
+    return directStrategy
+  }
+
+  if (trimmed.includes('{{encodedUrl}}')) {
+    return {
+      id: identifier,
+      build: (url) => trimmed.replace(/{{encodedUrl}}/g, encodeURIComponent(url.toString())),
+    }
+  }
+
+  if (trimmed.includes('{{url}}')) {
+    return {
+      id: identifier,
+      build: (url) => trimmed.replace(/{{url}}/g, url.toString()),
+    }
+  }
+
+  if (trimmed.includes('%s')) {
+    return {
+      id: identifier,
+      build: (url) => trimmed.replace(/%s/g, url.toString()),
+    }
+  }
+
+  if (/(?:\?|=|&)$/.test(trimmed)) {
+    return {
+      id: identifier,
+      build: (url) => `${trimmed}${encodeURIComponent(url.toString())}`,
+    }
+  }
+
+  const normalized = trimmed.endsWith('/') ? trimmed : `${trimmed}/`
+  return {
+    id: identifier,
+    build: (url) => `${normalized}${url.toString()}`,
+  }
+}
+
+const parseCustomTemplates = (raw: string) =>
+  raw
+    .split(/[\n,;]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+
+const defaultProxyStrategies: ProxyStrategy[] = [
+  createStrategyFromTemplate('https://cors.isomorphic-git.org/', 'cors-isomorphic'),
+  createStrategyFromTemplate('https://thingproxy.freeboard.io/fetch/', 'thingproxy'),
+  createStrategyFromTemplate('https://corsproxy.io/?', 'corsproxy-io'),
+  createStrategyFromTemplate('https://api.allorigins.win/raw?url=', 'allorigins'),
+  createStrategyFromTemplate('https://r.jina.ai/', 'r-jina'),
+]
+
+const appendDirectIfMissing = (strategies: ProxyStrategy[]) => {
+  if (strategies.some((strategy) => strategy.id === directStrategy.id)) {
+    return strategies
+  }
+
+  return [...strategies, directStrategy]
+}
+
+const resolveProxyStrategies = (): ProxyStrategy[] => {
+  const raw = import.meta.env.VITE_MARKET_DATA_PROXY
+  const trimmed = typeof raw === 'string' ? raw.trim() : ''
+
+  if (trimmed) {
+    const lowered = trimmed.toLowerCase()
+    if (disabledProxyValues.has(lowered)) {
+      return [directStrategy]
+    }
+
+    const entries = parseCustomTemplates(trimmed)
+    if (entries.length > 0) {
+      const customStrategies = entries
+        .map((entry, index) => {
+          if (disabledProxyValues.has(entry.toLowerCase())) {
+            return null
+          }
+          return createStrategyFromTemplate(entry, `custom-${index}`)
+        })
+        .filter((strategy): strategy is ProxyStrategy => Boolean(strategy))
+
+      if (customStrategies.length > 0) {
+        return appendDirectIfMissing(customStrategies)
+      }
+    }
+  }
+
+  return appendDirectIfMissing(defaultProxyStrategies)
+}
+
+const proxyStrategies = resolveProxyStrategies()
+
+const shouldRetryWithNextProxy = (response: Response) =>
+  [403, 429, 500, 502, 503, 504].includes(response.status)
+
+export const fetchWithProxies = async (url: URL, init?: RequestInit) => {
+  const finalInit: RequestInit = { ...init }
+  const headers = new Headers(init?.headers ?? {})
+
+  if (!headers.has('Accept')) {
+    headers.set('Accept', 'application/json, text/plain, */*')
+  }
+
+  finalInit.headers = headers
+
+  let lastError: unknown = null
+
+  for (let index = 0; index < proxyStrategies.length; index += 1) {
+    const strategy = proxyStrategies[index]
+    const targetUrl = strategy.build(url)
+    const isLast = index === proxyStrategies.length - 1
+
+    try {
+      const response = await fetch(targetUrl, finalInit)
+
+      if (!response.ok && !isLast && shouldRetryWithNextProxy(response)) {
+        lastError = new Error(`Proxy ${strategy.id} responded with status ${response.status}`)
+        if (response.body) {
+          try {
+            await response.body.cancel()
+          } catch {
+            // ignore cancellation errors
+          }
+        }
+        continue
+      }
+
+      return response
+    } catch (error) {
+      lastError = error
+    }
+  }
+
+  if (lastError instanceof Error) {
+    throw lastError
+  }
+
+  throw new Error('모든 프록시 요청이 실패했습니다.')
+}
+
+export { disabledProxyValues }


### PR DESCRIPTION
## Summary
- add a reusable proxy-aware fetch helper so market and news calls can cycle through fallback endpoints
- refactor the market overview and news feed components to rely on the helper, surface clearer status notices, and parse Google RSS data reliably
- tighten the dashboard styling so the market summary fits on a single row and chart cards take less width on desktop and mobile

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1e003544c8326b367fc048251732e