### PR TITLE
Improve market data reliability and focus news on US markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 | 데이터 | 출처 |
 | --- | --- |
 | 경제 캘린더 | [Financial Modeling Prep](https://financialmodelingprep.com/developer/docs/economic-calendar-api) (Investing.com 캘린더 참고) |
-| 지수 가격 | [Yahoo Finance Quote API](https://query1.finance.yahoo.com/v7/finance/quote) |
+| 지수 가격 | [Financial Modeling Prep Quote API](https://financialmodelingprep.com/developer/docs/stock-market/real-time-stock-prices/) |
 | 코인 가격 | [Binance 24hr Ticker API](https://binance-docs.github.io/apidocs/spot/en/#24hr-ticker-price-change-statistics) |
 | 경제 뉴스 | [Alpha Vantage News Sentiment API](https://www.alphavantage.co/documentation/) |
 | 차트 위젯 | [TradingView Advanced Chart](https://www.tradingview.com/widget/advanced-chart/) |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ function App() {
     <div className="app">
       <div className="app-inner">
         <header className="hero">
-          <h1>JH 투자 촉진위원회</h1>
+          <h1>JH Investment Lab</h1>
           <p>
             개인 투자자에게 꼭 필요한 달러 경제 지표, 글로벌 증시 및 코인 시세, 그리고 실시간 경제 뉴스를 한눈에
             확인하세요.
@@ -28,8 +28,8 @@ function App() {
         </main>
 
         <footer className="footer">
-          © {new Date().getFullYear()} JH 투자 촉진위원회 · 데이터 출처: Investing.com, Binance, Yahoo Finance,
-          AlphaVantage
+          © {new Date().getFullYear()} JH Investment Lab · 데이터 출처: Investing.com, Binance, Financial Modeling
+          Prep, AlphaVantage
         </footer>
       </div>
     </div>

--- a/src/components/NewsFeed.tsx
+++ b/src/components/NewsFeed.tsx
@@ -31,7 +31,48 @@ type FmpNewsItem = {
   id?: string | number
 }
 
+const relevantKeywordPatterns: RegExp[] = [
+  /미국\s*증시/i,
+  /미\s*증시/i,
+  /뉴욕\s*증시/i,
+  /미국\s*주식/i,
+  /월가/i,
+  /wall street/i,
+  /dow jones/i,
+  /nasdaq/i,
+  /nyse/i,
+  /s&p\s*500/i,
+  /s&p500/i,
+  /u\.?s\.?\s+(?:stock|stocks|market|markets)/i,
+  /us\s+(?:stock|stocks|market|markets)/i,
+  /비트코인/i,
+  /bitcoin/i,
+  /\bbtc\b/i,
+  /이더리움/i,
+  /ethereum/i,
+  /\beth\b/i,
+  /리플/i,
+  /\bxrp\b/i,
+  /암호화폐/i,
+  /crypto/i,
+  /cryptocurrency/i,
+  /코인/i,
+  /digital asset/i,
+  /blockchain/i,
+  /binance/i,
+  /coinbase/i,
+  /coindesk/i,
+  /cointelegraph/i,
+  /stablecoin/i,
+  /altcoin/i,
+]
+
 const stripHtml = (value: string) => value.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim()
+
+const isRelevantNewsItem = (item: NewsItem) => {
+  const haystack = [item.title, item.summary, item.source].filter(Boolean).join(' ')
+  return relevantKeywordPatterns.some((pattern) => pattern.test(haystack))
+}
 
 const parseAlphaVantagePublishedAt = (value?: string): Date | null => {
   if (!value) {
@@ -124,21 +165,21 @@ const NewsFeed = () => {
       if (fmpKey) {
         candidates.push({
           label: 'Financial Modeling Prep',
-          notice: 'Financial Modeling Prep 실시간 속보 API를 통해 제공됩니다.',
+          notice: 'Financial Modeling Prep 실시간 속보 API에서 미국 증시와 코인 뉴스를 선별했습니다.',
           loader: () => fetchFmpNews(fmpKey),
         })
       }
 
       candidates.push({
         label: 'Google 뉴스',
-        notice: 'Google 뉴스 Business RSS 피드를 통해 최신 소식을 제공합니다.',
+        notice: 'Google 뉴스 Business RSS에서 미국 증시와 코인 관련 기사를 선별했습니다.',
         loader: fetchGoogleNewsRss,
       })
 
       if (shouldUseAlpha && alphaVantageKey) {
         candidates.push({
           label: 'Alpha Vantage',
-          notice: 'Alpha Vantage 뉴스 API 기반 데이터입니다.',
+          notice: 'Alpha Vantage 뉴스 API에서 미국 증시 및 코인 이슈를 선별해 제공합니다.',
           loader: () => fetchAlphaVantageNews(alphaVantageKey),
         })
       }
@@ -202,8 +243,8 @@ const NewsFeed = () => {
     <section className="section" aria-labelledby="news-feed-heading">
       <div className="section-header">
         <div>
-          <h2 id="news-feed-heading">실시간 경제 속보</h2>
-          <span>중요도 높은 글로벌 경제 뉴스를 빠르게 확인하세요.</span>
+          <h2 id="news-feed-heading">실시간 미국 증시 · 코인 속보</h2>
+          <span>미국 증시와 주요 코인 관련 뉴스를 선별해 빠르게 전해드립니다.</span>
         </div>
       </div>
 
@@ -287,6 +328,7 @@ const fetchFmpNews = async (apiKey: string): Promise<NewsItem[]> => {
       }
     })
     .filter((item): item is NewsItem => Boolean(item))
+    .filter(isRelevantNewsItem)
     .sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime())
 }
 
@@ -326,6 +368,7 @@ const fetchAlphaVantageNews = async (apiKey: string): Promise<NewsItem[]> => {
       }
     })
     .filter((item): item is NewsItem => Boolean(item))
+    .filter(isRelevantNewsItem)
     .sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime())
 }
 
@@ -428,6 +471,7 @@ const parseGoogleNewsRss = (raw: string): NewsItem[] => {
       }
     })
     .filter((item): item is NewsItem => Boolean(item))
+    .filter(isRelevantNewsItem)
     .sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime())
 }
 

--- a/src/utils/proxyFetch.ts
+++ b/src/utils/proxyFetch.ts
@@ -119,6 +119,9 @@ export const fetchWithProxies = async (url: URL, init?: RequestInit) => {
   }
 
   finalInit.headers = headers
+  if (!finalInit.credentials) {
+    finalInit.credentials = 'omit'
+  }
 
   let lastError: unknown = null
 


### PR DESCRIPTION
## Summary
- switch Nasdaq and Dow pricing to the Financial Modeling Prep API, move crypto tickers to Binance, and enrich provider status handling with API-key messaging and direct Binance fallbacks for more reliable market data
- filter incoming headlines to U.S. market and crypto topics, updating notices and section copy so the news feed stays on-message
- update the site branding to “JH Investment Lab”, refresh documented data sources, and ensure proxy fetches omit credentials by default

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2071c0fdc83268fc04c5e2d950a4f