### PR TITLE
Add USD/KRW ticker and refine market overview data

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -123,6 +123,7 @@
   border-radius: 16px;
   background: rgba(15, 23, 42, 0.55);
   border: 1px solid rgba(71, 85, 105, 0.35);
+  margin-bottom: 1.5rem;
 }
 
 .market-summary-item {
@@ -201,6 +202,95 @@
   gap: 0.85rem;
   color: #e2e8f0;
   box-shadow: 0 18px 35px rgba(15, 23, 42, 0.28);
+}
+
+.fear-greed-card.prominent {
+  flex: 1 1 360px;
+}
+
+.usd-krw-card {
+  flex: 1 1 260px;
+  min-width: 0;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(71, 85, 105, 0.35);
+  border-radius: 16px;
+  padding: 1.15rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: #e2e8f0;
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.22);
+}
+
+.usd-krw-card[aria-busy='true'] .usd-krw-value {
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.usd-krw-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.usd-krw-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.7);
+  letter-spacing: 0.02em;
+}
+
+.usd-krw-subtitle {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.68);
+  white-space: nowrap;
+}
+
+.usd-krw-value-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.usd-krw-value {
+  font-size: 2rem;
+  line-height: 1;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.usd-krw-change {
+  font-size: 0.92rem;
+  font-weight: 600;
+  padding: 0.3rem 0.7rem;
+  border-radius: 10px;
+  border: 1px solid rgba(71, 85, 105, 0.4);
+  background: rgba(30, 41, 59, 0.6);
+  color: rgba(226, 232, 240, 0.78);
+  white-space: nowrap;
+}
+
+.usd-krw-change.up {
+  color: #4ade80;
+  border-color: rgba(74, 222, 128, 0.35);
+}
+
+.usd-krw-change.down {
+  color: #f87171;
+  border-color: rgba(248, 113, 113, 0.35);
+}
+
+.usd-krw-change.placeholder {
+  border-style: dashed;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.usd-krw-meta {
+  margin: 0;
+  font-size: 0.78rem;
+  color: rgba(148, 163, 184, 0.7);
+  line-height: 1.4;
 }
 
 .fear-greed-header {
@@ -568,11 +658,11 @@
   color: rgba(226, 232, 240, 0.75);
   font-size: 0.95rem;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 4;
   -webkit-box-orient: vertical;
   overflow: hidden;
   line-height: 1.45;
-  min-height: calc(1.45 * 2 * 0.95rem);
+  min-height: calc(1.45 * 4 * 0.95rem);
 }
 
 .news-meta {
@@ -613,6 +703,14 @@
   }
 
   .fear-greed-card {
+    flex: 1 1 auto;
+  }
+
+  .fear-greed-card.prominent {
+    flex: 1 1 auto;
+  }
+
+  .usd-krw-card {
     flex: 1 1 auto;
   }
 }


### PR DESCRIPTION
## Summary
- move the fear & greed index card to the top of the market overview and reconcile its sentiment label with the numeric value
- surface a USD/KRW rate widget beside the charts, reusing Yahoo Finance quotes and exposing more robust quote parsing for the U.S. index summaries
- expand the live news card summaries so two additional lines of text are visible for each item

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2286e06b0832681534b44ee0cdb1b