### PR TITLE
Add multi-source market data and layout enhancements

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -72,6 +72,97 @@
   font-size: 0.9rem;
 }
 
+.hero-bottom-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: stretch;
+  margin-top: 1.25rem;
+}
+
+.hero-bottom-row .badge-row {
+  flex: 1 1 420px;
+  margin-top: 0;
+}
+
+.exchange-rate-ticker {
+  flex: 0 0 260px;
+  min-width: 220px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 16px;
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.6rem;
+  color: #e2e8f0;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.22);
+}
+
+.exchange-rate-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.exchange-rate-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.75);
+  letter-spacing: 0.02em;
+}
+
+.exchange-rate-subtitle {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.7);
+  white-space: nowrap;
+}
+
+.exchange-rate-body {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.85rem;
+}
+
+.exchange-rate-value {
+  font-size: 1.85rem;
+  font-weight: 700;
+  color: #f8fafc;
+  line-height: 1;
+}
+
+.exchange-rate-change {
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 0.28rem 0.65rem;
+  border-radius: 10px;
+  border: 1px solid rgba(71, 85, 105, 0.4);
+  background: rgba(30, 41, 59, 0.6);
+  color: rgba(226, 232, 240, 0.78);
+  white-space: nowrap;
+}
+
+.exchange-rate-change.up {
+  color: #4ade80;
+  border-color: rgba(74, 222, 128, 0.35);
+}
+
+.exchange-rate-change.down {
+  color: #f87171;
+  border-color: rgba(248, 113, 113, 0.35);
+}
+
+.exchange-rate-change.placeholder {
+  border-style: dashed;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.exchange-rate-meta {
+  font-size: 0.78rem;
+  color: rgba(148, 163, 184, 0.72);
+}
+
 .section {
   background: rgba(15, 23, 42, 0.8);
   border-radius: 20px;
@@ -208,90 +299,48 @@
   flex: 1 1 360px;
 }
 
-.usd-krw-card {
-  flex: 1 1 260px;
-  min-width: 0;
+.yield-spread-card {
+  flex: 1 1 320px;
+  min-width: 260px;
   background: rgba(15, 23, 42, 0.55);
   border: 1px solid rgba(71, 85, 105, 0.35);
   border-radius: 16px;
   padding: 1.15rem 1.25rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.8rem;
   color: #e2e8f0;
   box-shadow: 0 18px 35px rgba(15, 23, 42, 0.22);
 }
 
-.usd-krw-card[aria-busy='true'] .usd-krw-value {
-  color: rgba(226, 232, 240, 0.65);
-}
-
-.usd-krw-header {
+.yield-spread-header {
   display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 0.5rem;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
-.usd-krw-title {
+.yield-spread-title {
   font-size: 0.85rem;
   font-weight: 600;
-  color: rgba(226, 232, 240, 0.7);
+  color: rgba(226, 232, 240, 0.75);
   letter-spacing: 0.02em;
 }
 
-.usd-krw-subtitle {
+.yield-spread-subtitle {
   font-size: 0.8rem;
-  color: rgba(148, 163, 184, 0.68);
-  white-space: nowrap;
+  color: rgba(148, 163, 184, 0.72);
 }
 
-.usd-krw-value-row {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.75rem;
-}
-
-.usd-krw-value {
-  font-size: 2rem;
-  line-height: 1;
-  font-weight: 700;
-  color: #f8fafc;
-}
-
-.usd-krw-change {
-  font-size: 0.92rem;
-  font-weight: 600;
-  padding: 0.3rem 0.7rem;
-  border-radius: 10px;
-  border: 1px solid rgba(71, 85, 105, 0.4);
-  background: rgba(30, 41, 59, 0.6);
-  color: rgba(226, 232, 240, 0.78);
-  white-space: nowrap;
-}
-
-.usd-krw-change.up {
-  color: #4ade80;
-  border-color: rgba(74, 222, 128, 0.35);
-}
-
-.usd-krw-change.down {
-  color: #f87171;
-  border-color: rgba(248, 113, 113, 0.35);
-}
-
-.usd-krw-change.placeholder {
-  border-style: dashed;
-  color: rgba(148, 163, 184, 0.75);
-}
-
-.usd-krw-meta {
+.yield-spread-meta {
   margin: 0;
   font-size: 0.78rem;
-  color: rgba(148, 163, 184, 0.7);
-  line-height: 1.4;
+  color: rgba(148, 163, 184, 0.72);
 }
+
+.yield-spread-card .chart-container {
+  min-height: 220px;
+}
+
 
 .fear-greed-header {
   display: flex;
@@ -306,6 +355,13 @@
   font-weight: 600;
   color: rgba(226, 232, 240, 0.7);
   letter-spacing: 0.02em;
+}
+
+.fear-greed-subtitle {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.78rem;
+  color: rgba(148, 163, 184, 0.72);
 }
 
 .fear-greed-value-row {
@@ -698,6 +754,23 @@
 }
 
 @media (max-width: 1024px) {
+  .hero-bottom-row {
+    flex-direction: column;
+  }
+
+  .hero-bottom-row .badge-row {
+    width: 100%;
+  }
+
+  .exchange-rate-ticker {
+    flex: 1 1 auto;
+  }
+
+  .yield-spread-card {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
   .market-top-row {
     flex-direction: column;
   }
@@ -710,9 +783,6 @@
     flex: 1 1 auto;
   }
 
-  .usd-krw-card {
-    flex: 1 1 auto;
-  }
 }
 
 @media (max-width: 768px) {
@@ -736,6 +806,10 @@
 
   .fear-greed-card {
     padding: 1rem 1.1rem;
+  }
+
+  .yield-spread-card {
+    padding: 1.05rem 1.1rem;
   }
 
   .fear-greed-value {
@@ -770,5 +844,13 @@
 
   .calendar-table {
     font-size: 0.9rem;
+  }
+
+  .exchange-rate-ticker {
+    padding: 0.9rem 1rem;
+  }
+
+  .exchange-rate-value {
+    font-size: 1.6rem;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import './App.css'
 import EconomicCalendar from './components/EconomicCalendar'
+import ExchangeRateTicker from './components/ExchangeRateTicker'
 import MarketOverview from './components/MarketOverview'
 import NewsFeed from './components/NewsFeed'
 
@@ -13,11 +14,14 @@ function App() {
             개인 투자자에게 꼭 필요한 달러 경제 지표, 글로벌 증시 및 코인 시세, 그리고 실시간 경제 뉴스를 한눈에
             확인하세요.
           </p>
-          <div className="badge-row">
-            <span className="badge">USD 경제 캘린더</span>
-            <span className="badge">나스닥 · 다우 실시간</span>
-            <span className="badge">비트코인 · 이더리움 · 리플</span>
-            <span className="badge">BGSC 선물 15분봉</span>
+          <div className="hero-bottom-row">
+            <div className="badge-row">
+              <span className="badge">USD 경제 캘린더</span>
+              <span className="badge">나스닥 · 다우 실시간</span>
+              <span className="badge">비트코인 · 이더리움 · 리플</span>
+              <span className="badge">BGSC 선물 15분봉</span>
+            </div>
+            <ExchangeRateTicker />
           </div>
         </header>
 

--- a/src/components/ExchangeRateTicker.tsx
+++ b/src/components/ExchangeRateTicker.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react'
+import { fetchYahooQuotes } from '../utils/marketData'
+import type { PriceInfo } from '../utils/marketData'
+
+const usdKrwSymbol = 'KRW=X' as const
+
+const formatPrice = (value: number | null | undefined) => {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  return new Intl.NumberFormat('ko-KR', {
+    style: 'currency',
+    currency: 'KRW',
+    minimumFractionDigits: value >= 1000 ? 0 : 2,
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
+const formatChange = (value: number | null | undefined) => {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  const formatted = value.toFixed(2)
+  const sign = value > 0 ? '+' : ''
+  return `${sign}${formatted}%`
+}
+
+const ExchangeRateTicker = () => {
+  const [rate, setRate] = useState<PriceInfo | null>(null)
+  const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('loading')
+
+  useEffect(() => {
+    let active = true
+
+    const loadRate = async (showLoading = false) => {
+      if (!active) {
+        return
+      }
+
+      if (showLoading) {
+        setStatus('loading')
+      }
+
+      try {
+        const quotes = await fetchYahooQuotes([usdKrwSymbol])
+        if (!active) {
+          return
+        }
+
+        const info = quotes[usdKrwSymbol] ?? null
+        const hasValue = info && (info.price !== null || info.changePercent !== null)
+        setRate(info)
+        setStatus(hasValue ? 'idle' : 'error')
+      } catch (error) {
+        console.error('원/달러 환율 로딩 실패', error)
+        if (!active) {
+          return
+        }
+
+        setRate(null)
+        setStatus('error')
+      }
+    }
+
+    loadRate(true)
+    const interval = window.setInterval(() => loadRate(false), 60_000)
+
+    return () => {
+      active = false
+      window.clearInterval(interval)
+    }
+  }, [])
+
+  const priceLabel = formatPrice(rate?.price)
+  const resolvedPriceLabel =
+    priceLabel ?? (status === 'loading' ? '불러오는 중' : status === 'error' ? '수신 실패' : '데이터 없음')
+
+  const changeLabel = formatChange(rate?.changePercent)
+  const changeClass = changeLabel
+    ? rate && rate.changePercent !== null && rate.changePercent !== undefined
+      ? rate.changePercent >= 0
+        ? 'exchange-rate-change up'
+        : 'exchange-rate-change down'
+      : 'exchange-rate-change'
+    : 'exchange-rate-change placeholder'
+
+  const fallbackChangeLabel = status === 'loading' ? '불러오는 중' : status === 'error' ? '수신 실패' : '데이터 없음'
+
+  return (
+    <div className="exchange-rate-ticker" aria-live="polite" data-state={status}>
+      <div className="exchange-rate-header">
+        <span className="exchange-rate-title">원/달러 환율</span>
+        <span className="exchange-rate-subtitle">KRW=X · 실시간</span>
+      </div>
+      <div className="exchange-rate-body">
+        <strong className="exchange-rate-value">{resolvedPriceLabel}</strong>
+        {changeLabel ? (
+          <span className={changeClass}>{changeLabel}</span>
+        ) : (
+          <span className={changeClass}>{fallbackChangeLabel}</span>
+        )}
+      </div>
+      <span className="exchange-rate-meta">야후 파이낸스 · 1분 간격 자동 갱신</span>
+    </div>
+  )
+}
+
+export default ExchangeRateTicker

--- a/src/components/YieldSpreadCard.tsx
+++ b/src/components/YieldSpreadCard.tsx
@@ -1,0 +1,18 @@
+import TradingViewChart from './TradingViewChart'
+
+const YieldSpreadCard = () => (
+  <div className="yield-spread-card" role="complementary" aria-labelledby="yield-spread-title">
+    <div className="yield-spread-header">
+      <span id="yield-spread-title" className="yield-spread-title">
+        미국 채권 2년-10년 스프레드
+      </span>
+      <span className="yield-spread-subtitle">US02Y - US10Y · 2년물 수익률 - 10년물 수익률</span>
+    </div>
+    <TradingViewChart symbol="TVC:US02Y-TVC:US10Y" interval="120" />
+    <p className="yield-spread-meta">
+      금리 스프레드가 마이너스로 내려갈수록 경기 침체 가능성이 커지는 경향이 있습니다.
+    </p>
+  </div>
+)
+
+export default YieldSpreadCard

--- a/src/utils/marketData.ts
+++ b/src/utils/marketData.ts
@@ -1,0 +1,228 @@
+import { fetchWithProxies } from './proxyFetch'
+
+type PriceInfo = {
+  price: number | null
+  changePercent: number | null
+}
+
+const parseNumericValue = (value: unknown): number | null => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) {
+      return null
+    }
+
+    const cleaned = trimmed.replace(/[,%()]/g, '')
+    if (!cleaned) {
+      return null
+    }
+
+    const parsed = Number.parseFloat(cleaned)
+    return Number.isNaN(parsed) ? null : parsed
+  }
+
+  return null
+}
+
+const fetchYahooQuotes = async (symbols: string[]): Promise<Record<string, PriceInfo>> => {
+  if (!symbols.length) {
+    return {}
+  }
+
+  const url = new URL('https://query1.finance.yahoo.com/v7/finance/quote')
+  url.searchParams.set('symbols', symbols.join(','))
+
+  const response = await fetchWithProxies(url)
+  if (!response.ok) {
+    throw new Error('Yahoo Finance 응답 오류')
+  }
+
+  const data = await response.json()
+  const results = (data?.quoteResponse?.result ?? []) as Array<{
+    symbol?: string
+    regularMarketPrice?: number | string | null
+    regularMarketChangePercent?: number | string | null
+  }>
+
+  const mapped: Record<string, PriceInfo> = {}
+  results.forEach((item) => {
+    if (!item.symbol) {
+      return
+    }
+
+    const price = parseNumericValue(item.regularMarketPrice)
+    const changePercent = parseNumericValue(item.regularMarketChangePercent)
+
+    mapped[item.symbol] = {
+      price,
+      changePercent,
+    }
+  })
+
+  return mapped
+}
+
+const fetchBinanceQuotes = async (symbols: string[]): Promise<Record<string, PriceInfo>> => {
+  if (!symbols.length) {
+    return {}
+  }
+
+  const url = new URL('https://api.binance.com/api/v3/ticker/24hr')
+  url.searchParams.set('symbols', JSON.stringify(symbols))
+  const headers = { Accept: 'application/json, text/plain, */*' }
+
+  const mapTickers = (
+    entries: Array<{ symbol: string; lastPrice?: string; priceChangePercent?: string }>
+  ) => {
+    const toNumber = (input?: string) => {
+      if (!input) {
+        return null
+      }
+      const parsed = Number.parseFloat(input)
+      return Number.isNaN(parsed) ? null : parsed
+    }
+
+    const mapped: Record<string, PriceInfo> = {}
+    entries.forEach((item) => {
+      mapped[item.symbol] = {
+        price: toNumber(item.lastPrice),
+        changePercent: toNumber(item.priceChangePercent),
+      }
+    })
+    return mapped
+  }
+
+  try {
+    const directResponse = await fetch(url.toString(), {
+      headers,
+      credentials: 'omit',
+    })
+    if (directResponse.ok) {
+      const payload = (await directResponse.json()) as Array<{
+        symbol: string
+        lastPrice?: string
+        priceChangePercent?: string
+      }>
+      return mapTickers(payload)
+    }
+    console.warn(`Binance 직접 응답 상태 코드: ${directResponse.status}`)
+  } catch (error) {
+    console.warn('Binance 직접 요청 실패, 프록시로 재시도합니다.', error)
+  }
+
+  const response = await fetchWithProxies(url, { headers })
+  if (!response.ok) {
+    throw new Error('Binance 응답 오류')
+  }
+
+  const data = (await response.json()) as Array<{
+    symbol: string
+    lastPrice?: string
+    priceChangePercent?: string
+  }>
+
+  return mapTickers(data)
+}
+
+const fetchGateIoQuotes = async (symbols: string[]): Promise<Record<string, PriceInfo>> => {
+  if (!symbols.length) {
+    return {}
+  }
+
+  const results = await Promise.all(
+    symbols.map(async (symbol) => {
+      const url = new URL('https://api.gateio.ws/api/v4/futures/usdt/tickers')
+      url.searchParams.set('contract', symbol)
+
+      const response = await fetchWithProxies(url)
+      if (!response.ok) {
+        throw new Error(`Gate.io ${symbol} 시세 응답 오류`)
+      }
+
+      const data = (await response.json()) as Array<{
+        contract?: string
+        last?: string
+        change_percentage?: string
+      }>
+
+      const entry = data.find((item) => item.contract === symbol)
+      if (!entry) {
+        return null
+      }
+
+      const toNumber = (input?: string) => {
+        if (!input) {
+          return null
+        }
+        const parsed = Number.parseFloat(input)
+        return Number.isNaN(parsed) ? null : parsed
+      }
+
+      return {
+        symbol,
+        price: toNumber(entry.last),
+        changePercent: toNumber(entry.change_percentage),
+      }
+    })
+  )
+
+  const mapped: Record<string, PriceInfo> = {}
+  results.forEach((item) => {
+    if (!item) {
+      return
+    }
+    mapped[item.symbol] = {
+      price: item.price ?? null,
+      changePercent: item.changePercent ?? null,
+    }
+  })
+
+  return mapped
+}
+
+const fetchFmpQuotes = async (
+  symbols: string[],
+  apiKey: string
+): Promise<Record<string, PriceInfo>> => {
+  if (!symbols.length || !apiKey) {
+    return {}
+  }
+
+  const encodedSymbols = symbols.map((symbol) => encodeURIComponent(symbol))
+  const url = new URL(
+    `https://financialmodelingprep.com/api/v3/quote/${encodedSymbols.join(',')}`
+  )
+  url.searchParams.set('apikey', apiKey)
+
+  const response = await fetchWithProxies(url)
+  if (!response.ok) {
+    throw new Error('Financial Modeling Prep 시세 응답 오류')
+  }
+
+  const data = (await response.json()) as Array<{
+    symbol?: string
+    price?: number | string | null
+    changesPercentage?: number | string | null
+  }>
+
+  const mapped: Record<string, PriceInfo> = {}
+  data.forEach((item) => {
+    if (!item.symbol) {
+      return
+    }
+
+    mapped[item.symbol] = {
+      price: parseNumericValue(item.price),
+      changePercent: parseNumericValue(item.changesPercentage),
+    }
+  })
+
+  return mapped
+}
+
+export type { PriceInfo }
+export { fetchBinanceQuotes, fetchFmpQuotes, fetchGateIoQuotes, fetchYahooQuotes, parseNumericValue }


### PR DESCRIPTION
## Summary
- refactor market data fetching into shared utilities with multi-provider fallbacks so Nasdaq and Dow prices load reliably
- add a crypto fear & greed variant plus a 2y-10y Treasury spread chart to the market overview top row
- move the USD/KRW ticker into the hero as a text widget and refresh styling to accommodate the new cards

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d22e33d4f88326a6ab651ec5cfae1b