### PR TITLE
Improve market data reliability and layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -33,6 +33,18 @@
   gap: 2rem;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .hero {
   display: grid;
   gap: 1rem;
@@ -76,7 +88,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
-  align-items: stretch;
+  align-items: center;
   margin-top: 1.25rem;
 }
 
@@ -86,81 +98,49 @@
 }
 
 .exchange-rate-ticker {
-  flex: 0 0 260px;
-  min-width: 220px;
-  background: rgba(15, 23, 42, 0.55);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  border-radius: 16px;
-  padding: 1rem 1.25rem;
-  display: grid;
-  gap: 0.6rem;
-  color: #e2e8f0;
-  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.22);
-}
-
-.exchange-rate-header {
-  display: flex;
-  justify-content: space-between;
+  flex: 0 1 auto;
+  display: inline-flex;
   align-items: baseline;
-  gap: 0.5rem;
+  gap: 0.45rem;
+  padding: 0;
+  color: rgba(226, 232, 240, 0.8);
+  font-size: 0.85rem;
+  line-height: 1.2;
 }
 
 .exchange-rate-title {
-  font-size: 0.85rem;
   font-weight: 600;
-  color: rgba(226, 232, 240, 0.75);
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
+  color: rgba(226, 232, 240, 0.7);
 }
 
-.exchange-rate-subtitle {
-  font-size: 0.8rem;
-  color: rgba(148, 163, 184, 0.7);
-  white-space: nowrap;
-}
-
-.exchange-rate-body {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.85rem;
+.exchange-rate-separator {
+  color: rgba(148, 163, 184, 0.6);
 }
 
 .exchange-rate-value {
-  font-size: 1.85rem;
   font-weight: 700;
+  font-size: 0.95rem;
   color: #f8fafc;
-  line-height: 1;
 }
 
 .exchange-rate-change {
-  font-size: 0.9rem;
+  font-size: 0.78rem;
   font-weight: 600;
-  padding: 0.28rem 0.65rem;
-  border-radius: 10px;
-  border: 1px solid rgba(71, 85, 105, 0.4);
-  background: rgba(30, 41, 59, 0.6);
-  color: rgba(226, 232, 240, 0.78);
+  color: rgba(226, 232, 240, 0.72);
   white-space: nowrap;
 }
 
 .exchange-rate-change.up {
   color: #4ade80;
-  border-color: rgba(74, 222, 128, 0.35);
 }
 
 .exchange-rate-change.down {
   color: #f87171;
-  border-color: rgba(248, 113, 113, 0.35);
 }
 
 .exchange-rate-change.placeholder {
-  border-style: dashed;
-  color: rgba(148, 163, 184, 0.75);
-}
-
-.exchange-rate-meta {
-  font-size: 0.78rem;
-  color: rgba(148, 163, 184, 0.72);
+  color: rgba(148, 163, 184, 0.7);
 }
 
 .section {

--- a/src/components/MarketOverview.tsx
+++ b/src/components/MarketOverview.tsx
@@ -6,11 +6,12 @@ import {
   fetchBinanceQuotes,
   fetchFmpQuotes,
   fetchGateIoQuotes,
+  fetchStooqQuotes,
   fetchYahooQuotes,
 } from '../utils/marketData'
 import type { PriceInfo } from '../utils/marketData'
 
-const priceProviders = ['yahoo', 'binance', 'gateio', 'fmp'] as const
+const priceProviders = ['yahoo', 'binance', 'gateio', 'fmp', 'stooq'] as const
 type PriceProvider = (typeof priceProviders)[number]
 
 const createProviderStatusState = (initial: 'idle' | 'loading' | 'error' = 'loading') =>
@@ -49,6 +50,7 @@ const assets: AssetConfig[] = [
     priceSources: [
       { provider: 'yahoo', symbol: '^IXIC' },
       { provider: 'fmp', symbol: '^IXIC' },
+      { provider: 'stooq', symbol: '^IXIC' },
     ],
     formatOptions: { maximumFractionDigits: 2 },
     tags: ['미 증시', '인덱스'],
@@ -61,6 +63,7 @@ const assets: AssetConfig[] = [
     priceSources: [
       { provider: 'yahoo', symbol: '^DJI' },
       { provider: 'fmp', symbol: '^DJI' },
+      { provider: 'stooq', symbol: '^DJI' },
     ],
     formatOptions: { maximumFractionDigits: 2 },
     tags: ['미 증시', '인덱스'],
@@ -121,6 +124,7 @@ const MarketOverview = () => {
       binance: new Set<string>(),
       gateio: new Set<string>(),
       fmp: new Set<string>(),
+      stooq: new Set<string>(),
     }
 
     assets.forEach((asset) => {
@@ -134,6 +138,7 @@ const MarketOverview = () => {
       binance: Array.from(symbolSets.binance),
       gateio: Array.from(symbolSets.gateio),
       fmp: Array.from(symbolSets.fmp),
+      stooq: Array.from(symbolSets.stooq),
     }
   }, [])
 
@@ -141,6 +146,7 @@ const MarketOverview = () => {
   const binanceSymbols = providerSymbols.binance
   const gateIoSymbols = providerSymbols.gateio
   const fmpSymbols = providerSymbols.fmp
+  const stooqSymbols = providerSymbols.stooq
 
   useEffect(() => {
     let active = true
@@ -167,6 +173,9 @@ const MarketOverview = () => {
         } else {
           missingProviders.push('fmp')
         }
+      }
+      if (stooqSymbols.length) {
+        tasks.push({ provider: 'stooq', promise: fetchStooqQuotes(stooqSymbols) })
       }
 
       if (!tasks.length) {
@@ -291,7 +300,7 @@ const MarketOverview = () => {
       active = false
       window.clearInterval(interval)
     }
-  }, [binanceSymbols, fmpApiKey, fmpSymbols, gateIoSymbols, yahooSymbols])
+  }, [binanceSymbols, fmpApiKey, fmpSymbols, gateIoSymbols, stooqSymbols, yahooSymbols])
 
   const formatPrice = (value: number | null, options?: Intl.NumberFormatOptions) => {
     if (value === null || value === undefined) {

--- a/src/components/YieldSpreadCard.tsx
+++ b/src/components/YieldSpreadCard.tsx
@@ -4,13 +4,14 @@ const YieldSpreadCard = () => (
   <div className="yield-spread-card" role="complementary" aria-labelledby="yield-spread-title">
     <div className="yield-spread-header">
       <span id="yield-spread-title" className="yield-spread-title">
-        미국 채권 2년-10년 스프레드
+        미국 채권 10년-2년 스프레드
       </span>
-      <span className="yield-spread-subtitle">US02Y - US10Y · 2년물 수익률 - 10년물 수익률</span>
+      <span className="yield-spread-subtitle">FRED:T10Y2Y · 10년물 수익률 - 2년물 수익률</span>
     </div>
-    <TradingViewChart symbol="TVC:US02Y-TVC:US10Y" interval="120" />
+    <TradingViewChart symbol="FRED:T10Y2Y" interval="D" />
     <p className="yield-spread-meta">
-      금리 스프레드가 마이너스로 내려갈수록 경기 침체 가능성이 커지는 경향이 있습니다.
+      금리 스프레드가 마이너스로 내려갈수록 장단기 금리 역전이 심화되어 경기 침체 가능성이 커지는
+      경향이 있습니다.
     </p>
   </div>
 )


### PR DESCRIPTION
## Summary
- add resilient USD/KRW ticker with ExchangeRate.host fallback and compact inline styling
- extend market overview to use Stooq quotes for major US indices when Yahoo/FMP are unavailable
- update yield spread card to use FRED data and clarify copy to avoid incorrect Apple chart

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2371450fc83269f36ecab24504563