### PR TITLE
Improve market data reliability and add oil ticker

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -99,13 +99,20 @@
 
 .exchange-rate-ticker {
   flex: 0 1 auto;
-  display: inline-flex;
-  align-items: baseline;
-  gap: 0.45rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
   padding: 0;
   color: rgba(226, 232, 240, 0.8);
   font-size: 0.85rem;
   line-height: 1.2;
+}
+
+.exchange-rate-row {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.45rem;
 }
 
 .exchange-rate-title {

--- a/src/components/ExchangeRateTicker.tsx
+++ b/src/components/ExchangeRateTicker.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react'
-import { fetchUsdKrwFromExchangeRateHost, fetchYahooQuotes } from '../utils/marketData'
+import { fetchFmpQuotes, fetchUsdKrwFromExchangeRateHost, fetchYahooQuotes } from '../utils/marketData'
 import type { PriceInfo } from '../utils/marketData'
 
 const usdKrwSymbol = 'KRW=X' as const
+const wtiSymbol = 'CL=F' as const
 
 const formatPrice = (value: number | null | undefined) => {
   if (value === null || value === undefined) {
@@ -29,7 +30,11 @@ const formatChange = (value: number | null | undefined) => {
 
 const ExchangeRateTicker = () => {
   const [rate, setRate] = useState<PriceInfo | null>(null)
-  const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('loading')
+  const [oil, setOil] = useState<PriceInfo | null>(null)
+  const [rateStatus, setRateStatus] = useState<'idle' | 'loading' | 'error'>('loading')
+  const [oilStatus, setOilStatus] = useState<'idle' | 'loading' | 'error'>('loading')
+
+  const fmpApiKey = import.meta.env.VITE_FMP_KEY?.trim()
 
   useEffect(() => {
     let active = true
@@ -40,7 +45,8 @@ const ExchangeRateTicker = () => {
       }
 
       if (showLoading) {
-        setStatus('loading')
+        setRateStatus('loading')
+        setOilStatus('loading')
       }
 
       const resolveStatus = (info: PriceInfo | null) => {
@@ -51,41 +57,86 @@ const ExchangeRateTicker = () => {
         return info.price !== null || info.changePercent !== null ? 'idle' : 'error'
       }
 
+      const symbols = [usdKrwSymbol, wtiSymbol] as const
+      let quotes: Record<string, PriceInfo> = {}
+
       try {
-        const quotes = await fetchYahooQuotes([usdKrwSymbol])
+        quotes = await fetchYahooQuotes([...symbols])
         if (!active) {
           return
         }
 
-        const info = quotes[usdKrwSymbol] ?? null
-        if (info && (info.price !== null || info.changePercent !== null)) {
-          setRate(info)
-          setStatus('idle')
-          return
+        const yahooRate = quotes[usdKrwSymbol] ?? null
+        const yahooOil = quotes[wtiSymbol] ?? null
+
+        if (yahooRate && (yahooRate.price !== null || yahooRate.changePercent !== null)) {
+          setRate(yahooRate)
+          setRateStatus('idle')
+        }
+
+        if (yahooOil && (yahooOil.price !== null || yahooOil.changePercent !== null)) {
+          setOil(yahooOil)
+          setOilStatus('idle')
         }
       } catch (error) {
-        console.warn('Yahoo 환율 기본 소스 로딩 실패, 대체 소스를 시도합니다.', error)
+        console.warn('Yahoo 시세 기본 소스 로딩 실패, 대체 소스를 시도합니다.', error)
       }
 
-      try {
-        const fallbackInfo = await fetchUsdKrwFromExchangeRateHost()
-        if (!active) {
-          return
-        }
+      const resolveRateFallback = async () => {
+        try {
+          const fallbackInfo = await fetchUsdKrwFromExchangeRateHost()
+          if (!active) {
+            return
+          }
 
-        setRate(fallbackInfo)
-        setStatus(resolveStatus(fallbackInfo))
-        if (!fallbackInfo) {
-          throw new Error('대체 환율 정보가 비어 있습니다.')
-        }
-      } catch (error) {
-        console.error('원/달러 환율 로딩 실패', error)
-        if (!active) {
-          return
-        }
+          setRate(fallbackInfo)
+          setRateStatus(resolveStatus(fallbackInfo))
+          if (!fallbackInfo) {
+            throw new Error('대체 환율 정보가 비어 있습니다.')
+          }
+        } catch (error) {
+          console.error('원/달러 환율 로딩 실패', error)
+          if (!active) {
+            return
+          }
 
-        setRate(null)
-        setStatus('error')
+          setRate(null)
+          setRateStatus('error')
+        }
+      }
+
+      const resolveOilFallback = async () => {
+        try {
+          const fallbackQuotes = await fetchFmpQuotes([wtiSymbol], fmpApiKey)
+          if (!active) {
+            return
+          }
+
+          const fallbackInfo = fallbackQuotes[wtiSymbol] ?? null
+          setOil(fallbackInfo)
+          setOilStatus(resolveStatus(fallbackInfo))
+          if (!fallbackInfo) {
+            throw new Error('대체 국제 유가 정보가 비어 있습니다.')
+          }
+        } catch (error) {
+          console.error('국제 유가 로딩 실패', error)
+          if (!active) {
+            return
+          }
+
+          setOil(null)
+          setOilStatus('error')
+        }
+      }
+
+      const nextRate = quotes[usdKrwSymbol] ?? null
+      if (!nextRate || (nextRate.price === null && nextRate.changePercent === null)) {
+        await resolveRateFallback()
+      }
+
+      const nextOil = quotes[wtiSymbol] ?? null
+      if (!nextOil || (nextOil.price === null && nextOil.changePercent === null)) {
+        await resolveOilFallback()
       }
     }
 
@@ -96,36 +147,84 @@ const ExchangeRateTicker = () => {
       active = false
       window.clearInterval(interval)
     }
-  }, [])
+  }, [fmpApiKey])
 
-  const priceLabel = formatPrice(rate?.price)
-  const resolvedPriceLabel =
-    priceLabel ?? (status === 'loading' ? '불러오는 중' : status === 'error' ? '수신 실패' : '데이터 없음')
+  const buildTickerView = (
+    info: PriceInfo | null,
+    status: 'idle' | 'loading' | 'error',
+    priceFormatter: (value: number | null | undefined) => string | null
+  ) => {
+    const priceLabel = priceFormatter(info?.price)
+    const resolvedPriceLabel =
+      priceLabel ?? (status === 'loading' ? '불러오는 중' : status === 'error' ? '수신 실패' : '데이터 없음')
 
-  const changeLabel = formatChange(rate?.changePercent)
-  const changeClass = changeLabel
-    ? rate && rate.changePercent !== null && rate.changePercent !== undefined
-      ? rate.changePercent >= 0
-        ? 'exchange-rate-change up'
-        : 'exchange-rate-change down'
-      : 'exchange-rate-change'
-    : 'exchange-rate-change placeholder'
+    const changeLabel = formatChange(info?.changePercent)
+    const changeClass = changeLabel
+      ? info && info.changePercent !== null && info.changePercent !== undefined
+        ? info.changePercent >= 0
+          ? 'exchange-rate-change up'
+          : 'exchange-rate-change down'
+        : 'exchange-rate-change'
+      : 'exchange-rate-change placeholder'
 
-  const fallbackChangeLabel = status === 'loading' ? '불러오는 중' : status === 'error' ? '수신 실패' : '데이터 없음'
+    const fallbackChangeLabel =
+      status === 'loading' ? '불러오는 중' : status === 'error' ? '수신 실패' : '데이터 없음'
+
+    return { resolvedPriceLabel, changeLabel, changeClass, fallbackChangeLabel }
+  }
+
+  const oilFormatter = (value: number | null | undefined) => {
+    if (value === null || value === undefined) {
+      return null
+    }
+
+    return new Intl.NumberFormat('ko-KR', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(value)
+  }
+
+  const rateView = buildTickerView(rate, rateStatus, formatPrice)
+  const oilView = buildTickerView(oil, oilStatus, oilFormatter)
+
+  const containerState =
+    rateStatus === 'loading' || oilStatus === 'loading'
+      ? 'loading'
+      : rateStatus === 'error' && oilStatus === 'error'
+        ? 'error'
+        : 'idle'
 
   return (
-    <div className="exchange-rate-ticker" aria-live="polite" data-state={status}>
-      <span className="exchange-rate-title">원/달러 환율</span>
-      <span aria-hidden="true" className="exchange-rate-separator">
-        ·
-      </span>
-      <span className="exchange-rate-value">{resolvedPriceLabel}</span>
-      {changeLabel ? (
-        <span className={changeClass}>{changeLabel}</span>
-      ) : (
-        <span className={changeClass}>{fallbackChangeLabel}</span>
-      )}
-      <span className="visually-hidden">KRW=X · 1분 간격 자동 갱신</span>
+    <div className="exchange-rate-ticker" aria-live="polite" data-state={containerState}>
+      <div className="exchange-rate-row">
+        <span className="exchange-rate-title">국제 유가 (WTI)</span>
+        <span aria-hidden="true" className="exchange-rate-separator">
+          ·
+        </span>
+        <span className="exchange-rate-value">{oilView.resolvedPriceLabel}</span>
+        {oilView.changeLabel ? (
+          <span className={oilView.changeClass}>{oilView.changeLabel}</span>
+        ) : (
+          <span className={oilView.changeClass}>{oilView.fallbackChangeLabel}</span>
+        )}
+        <span className="visually-hidden">CL=F · 1분 간격 자동 갱신</span>
+      </div>
+
+      <div className="exchange-rate-row">
+        <span className="exchange-rate-title">원/달러 환율</span>
+        <span aria-hidden="true" className="exchange-rate-separator">
+          ·
+        </span>
+        <span className="exchange-rate-value">{rateView.resolvedPriceLabel}</span>
+        {rateView.changeLabel ? (
+          <span className={rateView.changeClass}>{rateView.changeLabel}</span>
+        ) : (
+          <span className={rateView.changeClass}>{rateView.fallbackChangeLabel}</span>
+        )}
+        <span className="visually-hidden">KRW=X · 1분 간격 자동 갱신</span>
+      </div>
     </div>
   )
 }

--- a/src/components/MarketOverview.tsx
+++ b/src/components/MarketOverview.tsx
@@ -156,8 +156,6 @@ const MarketOverview = () => {
         provider: PriceProvider
         promise: Promise<Record<string, PriceInfo>>
       }> = []
-      const missingProviders: PriceProvider[] = []
-
       if (yahooSymbols.length) {
         tasks.push({ provider: 'yahoo', promise: fetchYahooQuotes(yahooSymbols) })
       }
@@ -168,11 +166,7 @@ const MarketOverview = () => {
         tasks.push({ provider: 'gateio', promise: fetchGateIoQuotes(gateIoSymbols) })
       }
       if (fmpSymbols.length) {
-        if (fmpApiKey) {
-          tasks.push({ provider: 'fmp', promise: fetchFmpQuotes(fmpSymbols, fmpApiKey) })
-        } else {
-          missingProviders.push('fmp')
-        }
+        tasks.push({ provider: 'fmp', promise: fetchFmpQuotes(fmpSymbols, fmpApiKey) })
       }
       if (stooqSymbols.length) {
         tasks.push({ provider: 'stooq', promise: fetchStooqQuotes(stooqSymbols) })
@@ -180,19 +174,10 @@ const MarketOverview = () => {
 
       if (!tasks.length) {
         if (active) {
-          setStatus(missingProviders.length ? 'error' : 'idle')
+          setStatus('idle')
           setPrices({})
-          const nextStatuses = createProviderStatusState('idle')
-          missingProviders.forEach((provider) => {
-            nextStatuses[provider] = 'error'
-          })
-          setProviderStatuses(nextStatuses)
-
-          const nextMessages = createProviderMessageState()
-          missingProviders.forEach((provider) => {
-            nextMessages[provider] = 'API 키 필요'
-          })
-          setProviderMessages(nextMessages)
+          setProviderStatuses(createProviderStatusState('idle'))
+          setProviderMessages(createProviderMessageState())
         }
         return
       }
@@ -203,18 +188,12 @@ const MarketOverview = () => {
         tasks.forEach(({ provider }) => {
           next[provider] = 'loading'
         })
-        missingProviders.forEach((provider) => {
-          next[provider] = 'error'
-        })
         return next
       })
       setProviderMessages((prev) => {
         const next = { ...prev }
         tasks.forEach(({ provider }) => {
           next[provider] = null
-        })
-        missingProviders.forEach((provider) => {
-          next[provider] = 'API 키 필요'
         })
         return next
       })

--- a/src/components/NewsFeed.tsx
+++ b/src/components/NewsFeed.tsx
@@ -67,7 +67,17 @@ const relevantKeywordPatterns: RegExp[] = [
   /altcoin/i,
 ]
 
-const stripHtml = (value: string) => value.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim()
+const decodeBasicHtmlEntities = (value: string) =>
+  value
+    .replace(/&nbsp;|&#160;|&#xA0;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+
+const stripHtml = (value: string) =>
+  decodeBasicHtmlEntities(value.replace(/<[^>]*>/g, ' ')).replace(/\s+/g, ' ').trim()
 
 const isRelevantNewsItem = (item: NewsItem) => {
   const haystack = [item.title, item.summary, item.source].filter(Boolean).join(' ')


### PR DESCRIPTION
## Summary
- show the WTI crude oil quote above the USD/KRW ticker with Yahoo/FMP fallbacks and refreshed styles
- harden market data fetching by adding safer proxy defaults, direct ExchangeRate.host usage, and an open dataset fallback
- normalize news summaries by decoding basic HTML entities such as non-breaking spaces

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d23f7f720c8326aa66732a81649dd0