### PR TITLE
Adjust hero ticker alignment

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -89,6 +89,9 @@
   flex-wrap: wrap;
   gap: 1rem;
   align-items: center;
+  justify-content: center;
+  align-content: center;
+  align-self: center;
   margin-top: 1.25rem;
 }
 
@@ -102,17 +105,19 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.35rem;
-  padding: 0;
+  justify-content: center;
+  align-self: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0;
   color: rgba(226, 232, 240, 0.8);
   font-size: 0.85rem;
-  line-height: 1.2;
+  line-height: 1.1;
 }
 
 .exchange-rate-row {
   display: inline-flex;
   align-items: baseline;
-  gap: 0.45rem;
+  gap: 0.35rem;
 }
 
 .exchange-rate-title {


### PR DESCRIPTION
## Summary
- center the hero bottom row container so the exchange rate ticker aligns vertically with the badge row
- tighten spacing within the exchange rate ticker for a more compact badge-aligned height

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d24f62e6188326a4b2c2d49222edc8