### PR TITLE
Replace Yahoo data sources with Stooq and alternative feeds

### DIFF
--- a/src/components/ExchangeRateTicker.tsx
+++ b/src/components/ExchangeRateTicker.tsx
@@ -1,13 +1,7 @@
 import { useEffect, useState } from 'react'
-import {
-  fetchFmpQuotes,
-  fetchUsdKrwFromExchangeRateHost,
-  fetchWtiFromStooq,
-  fetchYahooQuotes,
-} from '../utils/marketData'
+import { fetchFmpQuotes, fetchUsdKrwFromExchangeRateHost, fetchWtiFromStooq } from '../utils/marketData'
 import type { PriceInfo } from '../utils/marketData'
 
-const usdKrwSymbol = 'KRW=X' as const
 const wtiSymbol = 'CL=F' as const
 
 const formatPrice = (value: number | null | undefined) => {
@@ -44,148 +38,129 @@ const ExchangeRateTicker = () => {
   useEffect(() => {
     let active = true
 
-    const loadRate = async (showLoading = false) => {
+    const hasMeaningfulInfo = (info: PriceInfo | null) =>
+      Boolean(info && (info.price !== null || info.changePercent !== null))
+
+    const resolveRate = async (showLoading: boolean) => {
       if (!active) {
         return
       }
 
       if (showLoading) {
         setRateStatus('loading')
-        setOilStatus('loading')
       }
-
-      const hasMeaningfulInfo = (info: PriceInfo | null) =>
-        Boolean(info && (info.price !== null || info.changePercent !== null))
-
-      const symbols = [usdKrwSymbol, wtiSymbol] as const
-      let quotes: Record<string, PriceInfo> = {}
 
       try {
-        quotes = await fetchYahooQuotes([...symbols])
+        const info = await fetchUsdKrwFromExchangeRateHost()
         if (!active) {
           return
         }
 
-        const yahooRate = quotes[usdKrwSymbol] ?? null
-        const yahooOil = quotes[wtiSymbol] ?? null
-
-        if (hasMeaningfulInfo(yahooRate)) {
-          setRate(yahooRate)
+        if (hasMeaningfulInfo(info)) {
+          setRate(info)
           setRateStatus('idle')
+          return
         }
 
-        if (hasMeaningfulInfo(yahooOil)) {
-          setOil(yahooOil)
-          setOilStatus('idle')
-        }
+        console.error('원/달러 환율 데이터가 비어 있습니다.')
+        setRate(info)
       } catch (error) {
-        console.warn('Yahoo 시세 기본 소스 로딩 실패, 대체 소스를 시도합니다.', error)
-      }
-
-      const resolveRateFallback = async () => {
+        console.error('원/달러 환율 로딩 실패', error)
         if (!active) {
           return
         }
 
-        setRateStatus('loading')
-
-        try {
-          const fallbackInfo = await fetchUsdKrwFromExchangeRateHost()
-          if (!active) {
-            return
-          }
-
-          if (hasMeaningfulInfo(fallbackInfo)) {
-            setRate(fallbackInfo)
-            setRateStatus('idle')
-            return
-          }
-
-          console.error('원/달러 환율 대체 데이터가 비어 있습니다.')
-          setRate(fallbackInfo)
-        } catch (error) {
-          console.error('원/달러 환율 로딩 실패', error)
-          if (!active) {
-            return
-          }
-
-          setRate(null)
-        }
-
-        if (!active) {
-          return
-        }
-
-        setRateStatus('error')
+        setRate(null)
       }
 
-      const resolveOilFallback = async () => {
-        if (!active) {
-          return
-        }
-
-        setOilStatus('loading')
-        let lastAttempt: PriceInfo | null = null
-
-        try {
-          const fallbackQuotes = await fetchFmpQuotes([wtiSymbol], fmpApiKey)
-          if (!active) {
-            return
-          }
-
-          const fallbackInfo = fallbackQuotes[wtiSymbol] ?? null
-          lastAttempt = fallbackInfo
-
-          if (hasMeaningfulInfo(fallbackInfo)) {
-            setOil(fallbackInfo)
-            setOilStatus('idle')
-            return
-          }
-
-          console.warn('Financial Modeling Prep 국제 유가 데이터가 유효하지 않습니다. Stooq 데이터를 시도합니다.')
-        } catch (error) {
-          console.error('Financial Modeling Prep 국제 유가 로딩 실패, Stooq 데이터를 시도합니다.', error)
-        }
-
-        try {
-          const stooqInfo = await fetchWtiFromStooq()
-          if (!active) {
-            return
-          }
-
-          lastAttempt = stooqInfo
-          if (hasMeaningfulInfo(stooqInfo)) {
-            setOil(stooqInfo)
-            setOilStatus('idle')
-            return
-          }
-
-          console.error('Stooq 국제 유가 데이터가 비어 있습니다.')
-        } catch (error) {
-          console.error('Stooq 국제 유가 로딩 실패', error)
-        }
-
-        if (!active) {
-          return
-        }
-
-        setOil(lastAttempt)
-        setOilStatus('error')
+      if (!active) {
+        return
       }
 
-      const nextRate = quotes[usdKrwSymbol] ?? null
-      if (!hasMeaningfulInfo(nextRate)) {
-        await resolveRateFallback()
-      }
-
-      const nextOil = quotes[wtiSymbol] ?? null
-      if (!hasMeaningfulInfo(nextOil)) {
-        await resolveOilFallback()
-      }
+      setRateStatus('error')
     }
 
-    loadRate(true)
-    const interval = window.setInterval(() => loadRate(false), 60_000)
+    const resolveOil = async (showLoading: boolean) => {
+      if (!active) {
+        return
+      }
+
+      if (showLoading) {
+        setOilStatus('loading')
+      }
+
+      const updateIfValid = (info: PriceInfo | null) => {
+        if (hasMeaningfulInfo(info)) {
+          setOil(info)
+          setOilStatus('idle')
+          return true
+        }
+
+        return false
+      }
+
+      let lastAttempt: PriceInfo | null = null
+
+      try {
+        const stooqInfo = await fetchWtiFromStooq()
+        if (!active) {
+          return
+        }
+
+        lastAttempt = stooqInfo
+        if (updateIfValid(stooqInfo)) {
+          return
+        }
+
+        if (stooqInfo) {
+          console.warn('Stooq 국제 유가 데이터가 충분하지 않습니다. 추가 소스를 시도합니다.')
+        } else {
+          console.warn('Stooq 국제 유가 데이터를 가져오지 못했습니다. 추가 소스를 시도합니다.')
+        }
+      } catch (error) {
+        console.error('Stooq 국제 유가 로딩 실패', error)
+      }
+
+      if (!active) {
+        return
+      }
+
+      setOilStatus('loading')
+
+      try {
+        const fallbackQuotes = await fetchFmpQuotes([wtiSymbol], fmpApiKey)
+        if (!active) {
+          return
+        }
+
+        const fallbackInfo = fallbackQuotes[wtiSymbol] ?? null
+        lastAttempt = fallbackInfo ?? lastAttempt
+
+        if (updateIfValid(fallbackInfo)) {
+          return
+        }
+
+        console.warn('Financial Modeling Prep 국제 유가 데이터가 유효하지 않습니다.')
+      } catch (error) {
+        console.error('Financial Modeling Prep 국제 유가 로딩 실패', error)
+      }
+
+      if (!active) {
+        return
+      }
+
+      setOil(lastAttempt)
+      setOilStatus('error')
+    }
+
+    const loadAll = async (showLoading: boolean) => {
+      await Promise.all([resolveRate(showLoading), resolveOil(showLoading)])
+    }
+
+    loadAll(true)
+    const interval = window.setInterval(() => {
+      void loadAll(false)
+    }, 60_000)
 
     return () => {
       active = false


### PR DESCRIPTION
## Summary
- switch the exchange rate ticker to use ExchangeRate.host for USD/KRW and Stooq (with optional FMP fallback) for WTI so the widget works without a Yahoo feed or API key
- update the market overview so Nasdaq and Dow prices are sourced from Stooq with FMP as an optional provider instead of Yahoo
- enhance the Stooq quote helper to read the daily CSV series and derive change percentages from the latest two closes

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2538e12348326b8152d13d5ece521