### PR TITLE
Add live data guardrails and adjust hero ticker layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -46,14 +46,22 @@
 }
 
 .hero {
+  position: relative;
   display: grid;
-  gap: 0.85rem;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1.2rem 2.5rem;
   padding: 1.85rem 2rem;
   border-radius: 24px;
   background: linear-gradient(135deg, rgba(15, 118, 255, 0.35), rgba(14, 165, 233, 0.1));
   backdrop-filter: blur(18px);
   border: 1px solid rgba(148, 163, 184, 0.2);
   box-shadow: 0 25px 80px rgba(15, 118, 255, 0.15);
+}
+
+.hero-main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
 }
 
 .hero h1 {
@@ -73,7 +81,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  margin-top: 0.5rem;
+  margin-top: 0.75rem;
 }
 
 .hero .badge {
@@ -84,44 +92,48 @@
   font-size: 0.9rem;
 }
 
-.hero-bottom-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.85rem;
-  align-items: center;
-  justify-content: center;
-  align-content: center;
-  align-self: center;
-  margin-top: 0.85rem;
-}
-
-.hero-bottom-row .badge-row {
-  flex: 1 1 420px;
-  margin-top: 0;
-}
-
 .exchange-rate-ticker {
   flex: 0 1 auto;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  align-self: center;
-  gap: 0.35rem;
-  padding: 0.2rem 0;
-  color: rgba(226, 232, 240, 0.8);
+  align-items: flex-start;
+  justify-content: flex-start;
+  justify-self: end;
+  align-self: flex-start;
+  gap: 0.55rem;
+  padding: 0.25rem 0;
+  color: rgba(226, 232, 240, 0.85);
   font-size: 0.85rem;
   line-height: 1.1;
-  text-align: center;
+  text-align: left;
+  max-width: 320px;
 }
 
 .exchange-rate-row {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 0.5rem;
   flex-wrap: wrap;
   width: 100%;
+}
+
+@media (min-width: 768px) {
+  .hero {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 767px) {
+  .exchange-rate-ticker {
+    justify-self: stretch;
+    align-self: stretch;
+    max-width: none;
+    padding-top: 0.5rem;
+    border-top: 1px solid rgba(148, 163, 184, 0.25);
+    margin-top: 0.75rem;
+  }
 }
 
 .exchange-rate-title {
@@ -635,17 +647,18 @@
 
 .calendar-table thead th {
   text-align: left;
-  padding: 0.45rem 0.6rem 0.35rem 0;
+  padding: 0.3rem 0.5rem 0.25rem 0;
   color: rgba(226, 232, 240, 0.7);
   font-weight: 600;
   border-bottom: 1px solid rgba(148, 163, 184, 0.18);
 }
 
 .calendar-table tbody td {
-  padding: 0.45rem 0.6rem 0.45rem 0;
+  padding: 0.35rem 0.5rem 0.3rem 0;
   border-bottom: 1px solid rgba(51, 65, 85, 0.3);
   color: rgba(226, 232, 240, 0.92);
-  line-height: 1.28;
+  line-height: 1.2;
+  vertical-align: top;
 }
 
 .calendar-table tbody tr:last-child td {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,19 +9,19 @@ function App() {
     <div className="app">
       <div className="app-inner">
         <header className="hero">
-          <h1>JH Investment Lab</h1>
-          <p>
-            개인 투자자의 성공 투자를 위한 맞춤형 포탈 입니다. 전문가 상의가 필요하시면 엔서니와 상의하세요.
-          </p>
-          <div className="hero-bottom-row">
+          <div className="hero-main">
+            <h1>JH Investment Lab</h1>
+            <p>
+              개인 투자자의 성공 투자를 위한 맞춤형 포탈 입니다. 전문가 상의가 필요하시면 엔서니와 상의하세요.
+            </p>
             <div className="badge-row">
               <span className="badge">USD 경제 캘린더</span>
               <span className="badge">나스닥 · 다우 실시간</span>
               <span className="badge">비트코인 · 이더리움 · 리플</span>
               <span className="badge">BGSC 선물 15분봉</span>
             </div>
-            <ExchangeRateTicker />
           </div>
+          <ExchangeRateTicker />
         </header>
 
         <main className="content" aria-label="투자 인사이트">

--- a/src/components/EconomicCalendar.tsx
+++ b/src/components/EconomicCalendar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { shouldUseLiveCalendarData } from '../utils/liveDataFlags'
 
 type ViewMode = 'daily' | 'weekly'
 
@@ -354,8 +355,18 @@ const EconomicCalendar = () => {
   const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('loading')
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
+  const useLiveCalendar = shouldUseLiveCalendarData()
 
   useEffect(() => {
+    if (!useLiveCalendar) {
+      const fallbackBase = new Date()
+      setEvents(createFallbackEvents(fallbackBase))
+      setStatus('idle')
+      setLastUpdated(fallbackBase)
+      setNotice('실시간 경제 캘린더 API 사용이 비활성화되어 대표적인 USD 지표 예시 데이터를 표시합니다.')
+      return
+    }
+
     const controller = new AbortController()
 
     const loadEconomicEvents = async () => {
@@ -456,7 +467,7 @@ const EconomicCalendar = () => {
     })
 
     return () => controller.abort()
-  }, [])
+  }, [useLiveCalendar])
 
   const todayKey = useMemo(() => {
     const now = new Date()

--- a/src/components/ExchangeRateTicker.tsx
+++ b/src/components/ExchangeRateTicker.tsx
@@ -14,6 +14,7 @@ import {
   fallbackWti,
 } from '../utils/fallbackData'
 import type { PriceInfo } from '../utils/marketData'
+import { shouldUseLiveTickerData } from '../utils/liveDataFlags'
 
 const wtiSymbol = 'CL=F' as const
 const goldSymbol = 'GC=F' as const
@@ -60,8 +61,32 @@ const ExchangeRateTicker = () => {
   const [fallbackNotice, setFallbackNotice] = useState<string | null>(null)
 
   const fmpApiKey = import.meta.env.VITE_FMP_KEY?.trim()
+  const useLiveTickerData = shouldUseLiveTickerData()
 
   useEffect(() => {
+    if (!useLiveTickerData) {
+      setRate(fallbackUsdKrw)
+      setOil(fallbackWti)
+      setGold(fallbackGold)
+      setSilver(fallbackSilver)
+      setRateStatus('idle')
+      setOilStatus('idle')
+      setGoldStatus('idle')
+      setSilverStatus('idle')
+      setRateFallback(true)
+      setOilFallback(true)
+      setGoldFallback(true)
+      setSilverFallback(true)
+      setFallbackNotice(fallbackExchangeNotice)
+      return
+    }
+
+    setRateFallback(false)
+    setOilFallback(false)
+    setGoldFallback(false)
+    setSilverFallback(false)
+    setFallbackNotice(null)
+
     let active = true
 
     const hasMeaningfulInfo = (info: PriceInfo | null) =>
@@ -305,7 +330,7 @@ const ExchangeRateTicker = () => {
       active = false
       window.clearInterval(interval)
     }
-  }, [fmpApiKey])
+  }, [fmpApiKey, useLiveTickerData])
 
   useEffect(() => {
     if (rateFallback || oilFallback || goldFallback || silverFallback) {

--- a/src/components/FearGreedIndex.tsx
+++ b/src/components/FearGreedIndex.tsx
@@ -5,6 +5,7 @@ import {
   fallbackFearGreedNotice,
   getFallbackFearGreedHistory,
 } from '../utils/fallbackData'
+import { shouldUseLiveSentimentData } from '../utils/liveDataFlags'
 
 type FearGreedEntry = {
   value: number
@@ -341,8 +342,17 @@ const FearGreedIndex = ({ className, variant = 'us-market' }: FearGreedIndexProp
   const [history, setHistory] = useState<FearGreedEntry[]>([])
   const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('loading')
   const [notice, setNotice] = useState<string | null>(null)
+  const useLiveSentiment = shouldUseLiveSentimentData()
 
   useEffect(() => {
+    if (!useLiveSentiment) {
+      const fallbackHistory = getFallbackFearGreedHistory(variant)
+      setHistory(fallbackHistory)
+      setStatus('idle')
+      setNotice(fallbackHistory.length ? fallbackFearGreedNotice : null)
+      return
+    }
+
     let active = true
 
     const loadHistory = async (showLoading = false) => {
@@ -401,7 +411,7 @@ const FearGreedIndex = ({ className, variant = 'us-market' }: FearGreedIndexProp
       active = false
       window.clearInterval(interval)
     }
-  }, [variant])
+  }, [useLiveSentiment, variant])
 
   const latestEntry = history[0] ?? null
   const previousEntry = history[1] ?? null

--- a/src/components/NewsFeed.tsx
+++ b/src/components/NewsFeed.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { fetchWithProxies } from '../utils/proxyFetch'
 import { fallbackNewsNotice, getFallbackNews } from '../utils/fallbackData'
+import { shouldUseLiveNewsData } from '../utils/liveDataFlags'
 
 type NewsItem = {
   id: string
@@ -155,8 +156,17 @@ const NewsFeed = () => {
   const [news, setNews] = useState<NewsItem[]>([])
   const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('loading')
   const [notice, setNotice] = useState<string | null>(null)
+  const useLiveNews = shouldUseLiveNewsData()
 
   useEffect(() => {
+    if (!useLiveNews) {
+      const fallbackItems = getFallbackNews()
+      setNews(fallbackItems)
+      setStatus('idle')
+      setNotice(fallbackNewsNotice)
+      return
+    }
+
     let active = true
 
     const loadNews = async () => {
@@ -256,7 +266,7 @@ const NewsFeed = () => {
       active = false
       window.clearInterval(interval)
     }
-  }, [])
+  }, [useLiveNews])
 
   return (
     <section className="section" aria-labelledby="news-feed-heading">

--- a/src/utils/liveDataFlags.ts
+++ b/src/utils/liveDataFlags.ts
@@ -1,0 +1,63 @@
+const disabledValues = new Set(['0', 'false', 'off', 'no', 'disabled'])
+const enabledValues = new Set(['1', 'true', 'on', 'yes', 'enabled'])
+
+const parseBooleanFlag = (raw: string | undefined | null): boolean | null => {
+  if (raw === null || raw === undefined) {
+    return null
+  }
+
+  const normalized = raw.trim().toLowerCase()
+  if (!normalized) {
+    return null
+  }
+
+  if (disabledValues.has(normalized)) {
+    return false
+  }
+
+  if (enabledValues.has(normalized)) {
+    return true
+  }
+
+  return null
+}
+
+const defaultLiveFallback = !import.meta.env.DEV
+
+const resolveLiveDataFlag = (raw: string | undefined, fallback: boolean): boolean => {
+  const parsed = parseBooleanFlag(raw)
+  if (parsed !== null) {
+    return parsed
+  }
+
+  return fallback
+}
+
+const shouldUseLiveMarketData = () =>
+  resolveLiveDataFlag(import.meta.env.VITE_ENABLE_LIVE_MARKET_DATA, defaultLiveFallback)
+
+const shouldUseLiveTickerData = () => {
+  const explicit = parseBooleanFlag(import.meta.env.VITE_ENABLE_LIVE_TICKER_DATA)
+  if (explicit !== null) {
+    return explicit
+  }
+
+  return shouldUseLiveMarketData()
+}
+
+const shouldUseLiveNewsData = () =>
+  resolveLiveDataFlag(import.meta.env.VITE_ENABLE_LIVE_NEWS_DATA, defaultLiveFallback)
+
+const shouldUseLiveCalendarData = () =>
+  resolveLiveDataFlag(import.meta.env.VITE_ENABLE_LIVE_CALENDAR_DATA, defaultLiveFallback)
+
+const shouldUseLiveSentimentData = () =>
+  resolveLiveDataFlag(import.meta.env.VITE_ENABLE_LIVE_SENTIMENT_DATA, defaultLiveFallback)
+
+export {
+  shouldUseLiveCalendarData,
+  shouldUseLiveMarketData,
+  shouldUseLiveNewsData,
+  shouldUseLiveSentimentData,
+  shouldUseLiveTickerData,
+}


### PR DESCRIPTION
## Summary
- add configurable live-data flags so dev builds default to cached fallback data without CORS errors
- reposition the exchange rate ticker to the hero's top-right with left-aligned content and tighter economic table spacing
- default markets, news, sentiment, and calendar modules to fallback data when live feeds are disabled

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3498dd98c8326863fb9d9b063731f