### PR TITLE
Enable live data by default and center ticker

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,18 @@
 # .env
 VITE_FMP_KEY=your_financial_modeling_prep_key
 VITE_ALPHA_VANTAGE_KEY=your_alpha_vantage_key
+# 모든 실시간 호출을 비활성화하려면 0으로 설정 (기본값은 활성화)
+# VITE_DEFAULT_LIVE_DATA=0
+# 특정 위젯만 비활성화하려면 아래 플래그 중 하나를 0 또는 off 등으로 설정합니다.
+# VITE_ENABLE_LIVE_CALENDAR_DATA=1
+# VITE_ENABLE_LIVE_MARKET_DATA=1
+# VITE_ENABLE_LIVE_TICKER_DATA=1
+# VITE_ENABLE_LIVE_NEWS_DATA=1
+# VITE_ENABLE_LIVE_SENTIMENT_DATA=1
 ```
+
+> ℹ️ 개발 서버에서도 실시간 경제 캘린더와 시세 데이터를 바로 확인할 수 있도록 기본값을 "활성화"로 변경했습니다.
+> 외부 API 호출을 제한하고 싶다면 `VITE_DEFAULT_LIVE_DATA=0` 또는 각 영역별 `VITE_ENABLE_LIVE_*` 플래그를 `.env`에 추가하세요.
 
 ## 개발 및 빌드
 

--- a/src/App.css
+++ b/src/App.css
@@ -123,6 +123,10 @@
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: flex-start;
   }
+
+  .exchange-rate-ticker {
+    align-self: center;
+  }
 }
 
 @media (max-width: 767px) {

--- a/src/utils/liveDataFlags.ts
+++ b/src/utils/liveDataFlags.ts
@@ -22,7 +22,14 @@ const parseBooleanFlag = (raw: string | undefined | null): boolean | null => {
   return null
 }
 
-const defaultLiveFallback = !import.meta.env.DEV
+const defaultLiveFallback = (() => {
+  const explicitDefault = parseBooleanFlag(import.meta.env.VITE_DEFAULT_LIVE_DATA)
+  if (explicitDefault !== null) {
+    return explicitDefault
+  }
+
+  return true
+})()
 
 const resolveLiveDataFlag = (raw: string | undefined, fallback: boolean): boolean => {
   const parsed = parseBooleanFlag(raw)

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,14 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  readonly VITE_ALPHA_VANTAGE_KEY?: string
+  readonly VITE_DEFAULT_LIVE_DATA?: string
+  readonly VITE_ENABLE_LIVE_CALENDAR_DATA?: string
+  readonly VITE_ENABLE_LIVE_MARKET_DATA?: string
+  readonly VITE_ENABLE_LIVE_NEWS_DATA?: string
+  readonly VITE_ENABLE_LIVE_SENTIMENT_DATA?: string
+  readonly VITE_ENABLE_LIVE_TICKER_DATA?: string
+  readonly VITE_FMP_KEY?: string
   readonly VITE_MARKET_DATA_PROXY?: string
 }
 


### PR DESCRIPTION
## Summary
- enable live data integrations by default while allowing override via `VITE_DEFAULT_LIVE_DATA`
- document the new environment flags and add typings for the Vite variables
- center the exchange rate ticker in the hero layout for better vertical balance

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d34f987e048326b72fbd79539f7c8d