### PR TITLE
Improve consultation storage and adjust calendar text

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1070,6 +1070,11 @@
   text-align: center;
 }
 
+.consultation-status-notice {
+  background: rgba(37, 99, 235, 0.18);
+  color: rgba(191, 219, 254, 0.95);
+}
+
 .consultation-status-error {
   background: rgba(239, 68, 68, 0.15);
   color: rgba(252, 165, 165, 0.95);
@@ -1109,6 +1114,18 @@
 .consultation-message-contact {
   font-size: 0.85rem;
   color: rgba(148, 163, 184, 0.8);
+}
+
+.consultation-message-badge {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: rgba(191, 219, 254, 0.95);
+  background: rgba(37, 99, 235, 0.2);
+  border: 1px solid rgba(191, 219, 254, 0.35);
+  border-radius: 9999px;
+  padding: 0.15rem 0.55rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .consultation-message-body {

--- a/src/components/EconomicCalendar.tsx
+++ b/src/components/EconomicCalendar.tsx
@@ -461,9 +461,10 @@ const EconomicCalendar = () => {
                 />
               </svg>
             </span>
-            <span className="section-title-text">USD 주요 경제 지표 캘린더</span>
+            <span className="section-title-text">
+              USD 주요 경제 지표 캘린더  (Trading Economics 데이터를 기반으로 미국 달러 핵심 이벤트를 확인하세요.)
+            </span>
           </h2>
-          <span>Trading Economics 데이터를 기반으로 미국 달러 핵심 이벤트를 확인하세요.</span>
         </div>
         <div className="calendar-controls" role="group" aria-label="경제 캘린더 보기 옵션">
           <div className="segmented-control" role="tablist" aria-label="기간 선택">
@@ -526,13 +527,6 @@ const EconomicCalendar = () => {
           </div>
         </div>
       </div>
-
-      {status === 'error' && (
-        <div className="status-banner" role="alert">
-          경제 지표를 불러오는 중 문제가 발생하여 예시 데이터를 표시합니다. 잠시 후 다시 시도해주세요.
-        </div>
-      )}
-
       {status === 'loading' ? (
         <div className="status-banner" role="status">
           경제 캘린더 데이터를 불러오는 중입니다...

--- a/src/components/FearGreedIndex.tsx
+++ b/src/components/FearGreedIndex.tsx
@@ -61,6 +61,9 @@ const chartConfig = {
   paddingY: 10,
 }
 
+const normalizeUsIndexValue = (value: number) =>
+  Number.isFinite(value) ? Math.round(value) : value
+
 const formatUpdatedAt = (value: Date | null) => {
   if (!value) {
     return '-'
@@ -220,6 +223,7 @@ const parseUsFearGreedResponse = (payload: unknown): FearGreedEntry[] => {
     if (value === null) {
       return
     }
+    const normalizedValue = normalizeUsIndexValue(value)
     const timestamp = parseTimestampValue(timestampRaw)
     if (!timestamp) {
       return
@@ -227,9 +231,9 @@ const parseUsFearGreedResponse = (payload: unknown): FearGreedEntry[] => {
     const classification =
       typeof ratingRaw === 'string' && ratingRaw.trim().length > 0
         ? ratingRaw.trim()
-        : resolveToneByValue(value).label
+        : resolveToneByValue(normalizedValue).label
     entries.push({
-      value,
+      value: normalizedValue,
       classification,
       timestamp,
     })


### PR DESCRIPTION
## Summary
- add a localStorage-backed fallback for the consultation board, showing notices when offline entries are stored and tagging unsent items
- tweak consultation styles to support the new notices and badges
- round the US fear & greed index display and refresh the economic calendar header copy while removing the redundant error banner

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3844a78e0832685580020b685873d