### PR TITLE
Add Investing.com fallback widget for economic calendar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -711,6 +711,83 @@
   border-bottom: none;
 }
 
+.calendar-data-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.calendar-data-panel .status-banner {
+  margin-bottom: 0;
+}
+
+.calendar-combined-layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+  .calendar-combined-layout {
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+    align-items: flex-start;
+  }
+}
+
+.calendar-widget-card {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 18px;
+  padding: 1.25rem 1.35rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03), 0 18px 45px rgba(15, 23, 42, 0.4);
+}
+
+.calendar-widget-title {
+  margin: 0 0 0.2rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.calendar-widget-description {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.85);
+  line-height: 1.5;
+  font-size: 0.9rem;
+}
+
+.calendar-widget-frame {
+  border-radius: 14px;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(71, 85, 105, 0.4);
+}
+
+.calendar-widget-frame iframe {
+  display: block;
+  width: 100%;
+  border: 0;
+  min-height: 480px;
+}
+
+.calendar-widget-footnote {
+  margin: 0;
+  font-size: 0.78rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.calendar-widget-footnote a {
+  color: #60a5fa;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.calendar-widget-footnote a:hover {
+  text-decoration: underline;
+}
+
 .impact-chip {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- embed an Investing.com economic calendar widget whenever the Trading Economics feed is unavailable or disabled
- replace the previous error banner with friendly messaging and keep the fallback event list alongside the widget
- add styling hooks so the widget and table share a balanced layout and visual treatment

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3956f8ee083269b9aa9f41cdd07e0