### PR TITLE
Remove broken Investing.com widget fallback

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -772,6 +772,42 @@
   min-height: 480px;
 }
 
+.calendar-widget-frame--fallback {
+  padding: 1.25rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.calendar-widget-fallback-message {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.85);
+  line-height: 1.6;
+  font-size: 0.92rem;
+}
+
+.calendar-widget-fallback-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.55rem 1.05rem;
+  border-radius: 999px;
+  border: 1px solid rgba(59, 130, 246, 0.45);
+  background: rgba(96, 165, 250, 0.2);
+  color: #bfdbfe;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.calendar-widget-fallback-link:hover,
+.calendar-widget-fallback-link:focus-visible {
+  background: rgba(96, 165, 250, 0.32);
+  border-color: rgba(96, 165, 250, 0.6);
+  outline: none;
+}
+
 .calendar-widget-footnote {
   margin: 0;
   font-size: 0.78rem;

--- a/src/components/EconomicCalendar.tsx
+++ b/src/components/EconomicCalendar.tsx
@@ -133,10 +133,9 @@ const fallbackTemplates: FallbackEventTemplate[] = [
   },
 ]
 
-const INVESTING_WIDGET_URL =
-  'https://sslecal2.investing.com/events_economic_calendar.php?importance=3&countries=5&columns=exc_importance,exc_actual,exc_forecast,exc_previous&calType=week&timeZone=55&lang=1'
+const INVESTING_CALENDAR_PAGE_URL = 'https://www.investing.com/economic-calendar/'
 const INVESTING_WIDGET_NOTICE =
-  'Investing.com 실시간 캘린더 위젯으로 미국(USD) 핵심 경제 이벤트를 바로 확인하세요.'
+  'Trading Economics API 연결이 원활하지 않아 기본 예시 데이터를 표시하고 있습니다. 최신 일정은 Investing.com 경제 캘린더에서 확인하세요.'
 
 const formatNumber = (value?: string | number | null) => {
   if (value === null || value === undefined) {
@@ -324,26 +323,31 @@ const combineBaseAndPath = (base: string, path: string) => {
   return `${base}${normalizedPath}`
 }
 
-const InvestingCalendarWidget = () => (
+const InvestingCalendarFallbackCard = () => (
   <div className="calendar-widget-card" aria-live="polite">
     <div>
-      <h3 className="calendar-widget-title">Investing.com 실시간 미국 주요 지표</h3>
+      <h3 className="calendar-widget-title">Investing.com 미국 주요 지표 바로가기</h3>
       <p className="calendar-widget-description">
-        Investing.com 위젯에서 중요도 '높음' 이벤트를 실시간으로 불러와 미국 달러 관련 핵심 일정을 제공합니다.
+        Investing.com 경제 캘린더에서 최신 발표 일정을 직접 확인하실 수 있습니다. 아래 링크는 새 탭에서 열립니다.
       </p>
     </div>
-    <div className="calendar-widget-frame">
-      <iframe
-        title="Investing.com 미국 중요 경제지표 캘린더"
-        src={INVESTING_WIDGET_URL}
-        loading="lazy"
-        frameBorder={0}
-        style={{ width: '100%', minHeight: '480px', border: '0' }}
-        aria-label="Investing.com 경제 캘린더 실시간 위젯"
-      />
+    <div className="calendar-widget-frame calendar-widget-frame--fallback" role="alert">
+      <p className="calendar-widget-fallback-message">
+        Investing.com에서 제공하던 실시간 위젯 경로가 더 이상 지원되지 않아 예시 데이터를 함께 안내해 드리고 있습니다. 자세한 일정은
+        공식 페이지에서 확인해 주세요.
+      </p>
+      <a
+        className="calendar-widget-fallback-link"
+        href={INVESTING_CALENDAR_PAGE_URL}
+        target="_blank"
+        rel="noreferrer"
+        aria-label="Investing.com 경제 캘린더 페이지 새 창에서 열기"
+      >
+        Investing.com 경제 캘린더 열기
+      </a>
     </div>
     <p className="calendar-widget-footnote">
-      데이터 제공: <a href="https://www.investing.com/economic-calendar/" target="_blank" rel="noreferrer">Investing.com</a>
+      데이터 제공: <a href={INVESTING_CALENDAR_PAGE_URL} target="_blank" rel="noreferrer">Investing.com</a>
     </p>
   </div>
 )
@@ -639,7 +643,7 @@ const EconomicCalendar = () => {
         </div>
       ) : widgetFallbackActive ? (
         <div className="calendar-combined-layout">
-          <InvestingCalendarWidget />
+          <InvestingCalendarFallbackCard />
           {calendarTable}
         </div>
       ) : (


### PR DESCRIPTION
## Summary
- replace the deprecated Investing.com iframe widget with a static fallback card that links to the economic calendar page
- adjust the fallback notice text to explain the change and direct users to Investing.com for live data
- add supporting styles for the new fallback card presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3a0be51e083269bfea0ff0d38f7af