### PR TITLE
Restore investing widget fallback and add consultation email option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ VITE_ALPHA_VANTAGE_KEY=your_alpha_vantage_key
 # VITE_CALENDAR_API_BASE_URL=
 # 상담창구 API 서버 기본 주소 (예: https://api.example.com 또는 https://api.example.com/api)
 # VITE_CONSULTATION_API_BASE_URL=
+# 상담 요청을 이메일로도 수신하려면 주소를 지정하세요 (예: consult@example.com)
+# VITE_CONSULTATION_MAILTO=
 # 모든 실시간 호출을 비활성화하려면 0으로 설정 (기본값은 활성화)
 # VITE_DEFAULT_LIVE_DATA=0
 # 특정 위젯만 비활성화하려면 아래 플래그 중 하나를 0 또는 off 등으로 설정합니다.
@@ -68,3 +70,4 @@ npm run preview      # 빌드 검증
 - 외부 API의 CORS 정책이나 호출 제한에 따라 데이터 로드가 지연되거나 실패할 수 있습니다.
 - TradingView 위젯은 외부 스크립트를 로드하므로 네트워크 차단 환경에서는 표시되지 않을 수 있습니다.
 - BGSC 선물 시세는 차트 중심으로 제공되며, 별도 가격 API가 필요하면 `MarketOverview` 구성에서 쉽게 확장할 수 있습니다.
+- 상담창구 백엔드 연결이 불안정할 경우 입력 내용은 기기에 임시 저장되고, `VITE_CONSULTATION_MAILTO`를 지정하면 이메일 앱을 통해 직접 전송할 수 있습니다.

--- a/src/App.css
+++ b/src/App.css
@@ -761,51 +761,56 @@
 .calendar-widget-frame {
   border-radius: 14px;
   overflow: hidden;
-  background: rgba(15, 23, 42, 0.8);
+  background: rgba(15, 23, 42, 0.82);
   border: 1px solid rgba(71, 85, 105, 0.4);
+  position: relative;
+  min-height: 22.5rem;
 }
 
 .calendar-widget-frame iframe {
   display: block;
   width: 100%;
   border: 0;
-  min-height: 480px;
+  min-height: 22.5rem;
+  opacity: 0;
+  transition: opacity 0.35s ease;
 }
 
-.calendar-widget-frame--fallback {
-  padding: 1.25rem 1.1rem;
+.calendar-widget-frame--ready iframe {
+  opacity: 1;
+}
+
+.calendar-widget-loader {
+  position: absolute;
+  inset: 0;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  align-items: flex-start;
-}
-
-.calendar-widget-fallback-message {
-  margin: 0;
-  color: rgba(226, 232, 240, 0.85);
-  line-height: 1.6;
-  font-size: 0.92rem;
-}
-
-.calendar-widget-fallback-link {
-  display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
-  padding: 0.55rem 1.05rem;
-  border-radius: 999px;
-  border: 1px solid rgba(59, 130, 246, 0.45);
-  background: rgba(96, 165, 250, 0.2);
-  color: #bfdbfe;
-  font-weight: 600;
-  text-decoration: none;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  justify-content: center;
+  gap: 0.85rem;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.88));
+  color: rgba(226, 232, 240, 0.9);
+  font-size: 0.95rem;
+  text-align: center;
+  padding: 1rem 1.2rem;
 }
 
-.calendar-widget-fallback-link:hover,
-.calendar-widget-fallback-link:focus-visible {
-  background: rgba(96, 165, 250, 0.32);
-  border-color: rgba(96, 165, 250, 0.6);
-  outline: none;
+.calendar-widget-spinner {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 3px solid rgba(96, 165, 250, 0.25);
+  border-top-color: #60a5fa;
+  animation: calendar-widget-spin 1s linear infinite;
+}
+
+@keyframes calendar-widget-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .calendar-widget-footnote {
@@ -818,6 +823,12 @@
   color: #60a5fa;
   font-weight: 600;
   text-decoration: none;
+}
+
+.calendar-widget-footnote-hint {
+  display: block;
+  margin-top: 0.45rem;
+  color: rgba(226, 232, 240, 0.8);
 }
 
 .calendar-widget-footnote a:hover {
@@ -1146,6 +1157,35 @@
   box-shadow: none;
 }
 
+.consultation-mailto-button {
+  margin-top: 0.75rem;
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.6rem 1.15rem;
+  border-radius: 999px;
+  border: 1px dashed rgba(94, 234, 212, 0.5);
+  background: rgba(45, 212, 191, 0.12);
+  color: #5eead4;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.consultation-mailto-button:hover,
+.consultation-mailto-button:focus-visible {
+  background: rgba(45, 212, 191, 0.22);
+  border-color: rgba(94, 234, 212, 0.8);
+  color: #99f6e4;
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.consultation-mailto-button:focus-visible {
+  box-shadow: 0 0 0 2px rgba(45, 212, 191, 0.35);
+}
+
 .consultation-helper {
   margin: 0;
   font-size: 0.85rem;
@@ -1263,6 +1303,18 @@
   margin: 0;
   color: rgba(226, 252, 236, 0.75);
   font-size: 0.95rem;
+}
+
+.consultation-note a {
+  color: #38bdf8;
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.consultation-note a:hover,
+.consultation-note a:focus-visible {
+  color: #bae6fd;
+  outline: none;
 }
 
 .footer {


### PR DESCRIPTION
## Summary
- restore the USD economic calendar fallback to embed the updated Investing.com widget with a loading state and manual link hint
- add email fallback utilities for the consultation board, including manual email sending, offline storage messaging, and updated helper text
- style the new widget loader and consultation email button and document the optional `VITE_CONSULTATION_MAILTO` configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d47c7c35348326a2e64c2c92d7e98e