### PR TITLE
Fix economic calendar widget and add consultation fallback

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1281,6 +1281,12 @@
   letter-spacing: 0.04em;
 }
 
+.consultation-message-badge--external {
+  color: rgba(254, 249, 195, 0.95);
+  background: rgba(217, 119, 6, 0.28);
+  border-color: rgba(251, 191, 36, 0.45);
+}
+
 .consultation-message-body {
   color: rgba(226, 232, 240, 0.82);
   font-size: 0.95rem;

--- a/src/components/EconomicCalendar.tsx
+++ b/src/components/EconomicCalendar.tsx
@@ -135,7 +135,7 @@ const fallbackTemplates: FallbackEventTemplate[] = [
 
 const INVESTING_CALENDAR_PAGE_URL = 'https://www.investing.com/economic-calendar/'
 const INVESTING_WIDGET_EMBED_URL =
-  'https://sslecal2.investing.com/events_economic_calendar.php?importance=3&country=5&columns=exc_country,exc_importance,exc_actual,exc_forecast,exc_previous&theme=dark'
+  'https://sslecal2.forexprostools.com/?importance=3&country=5&columns=exc_country,exc_importance,exc_actual,exc_forecast,exc_previous&calType=week&timeZone=88&lang=51&theme=dark'
 const INVESTING_WIDGET_LOAD_TIMEOUT_MS = 8000
 const INVESTING_WIDGET_NOTICE =
   'Trading Economics API 연결이 원활하지 않아 Investing.com 위젯을 불러오고 있습니다. 위젯이 표시되지 않으면 공식 페이지에서 최신 일정을 확인하세요.'


### PR DESCRIPTION
## Summary
- update the Investing.com economic calendar fallback iframe to the current forexprostools endpoint
- add a public bulletin board fallback for the consultation feature, including fetching recent posts and sending submissions when the primary API fails
- surface new UI notices and badge styling to highlight external board entries and warn users about sensitive data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d487f86914832683ac42640be67002