### PR TITLE
feat: improve economic calendar and market data sourcing

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -761,19 +761,27 @@
 .calendar-widget-frame {
   border-radius: 14px;
   overflow: hidden;
-  background: rgba(15, 23, 42, 0.82);
-  border: 1px solid rgba(71, 85, 105, 0.4);
+  background: #020617;
+  border: 1px solid rgba(71, 85, 105, 0.55);
   position: relative;
-  min-height: 22.5rem;
+  min-height: 33.75rem;
 }
 
 .calendar-widget-frame iframe {
   display: block;
   width: 100%;
   border: 0;
-  min-height: 22.5rem;
+  min-height: 33.75rem;
+  background: #020617;
   opacity: 0;
   transition: opacity 0.35s ease;
+}
+
+@media (max-width: 640px) {
+  .calendar-widget-frame,
+  .calendar-widget-frame iframe {
+    min-height: 26rem;
+  }
 }
 
 .calendar-widget-frame--ready iframe {

--- a/src/components/EconomicCalendar.tsx
+++ b/src/components/EconomicCalendar.tsx
@@ -1,13 +1,14 @@
 const INVESTING_ECONOMIC_CALENDAR_IFRAME = `<!-- Investing.com Economic Calendar Widget -->
-<iframe 
-  src="https://sslecal2.investing.com?columns=exc_currency,exc_importance,exc_actual,exc_forecast,exc_previous&importance=3&country=5&calType=day&timeZone=8" 
-  width="100%" 
-  height="600" 
-  frameborder="0" 
-  allowtransparency="true" 
-  marginwidth="0" 
-  marginheight="0">
-</iframe>
+<iframe
+  src="https://sslecal2.investing.com?columns=exc_currency,exc_importance,exc_actual,exc_forecast,exc_previous&importance=3&country=5&calType=day&timeZone=8&theme=dark&lang=24"
+  width="100%"
+  height="540"
+  frameborder="0"
+  allowtransparency="true"
+  style="background:#020617;color:#e2e8f0;"
+  marginwidth="0"
+  marginheight="0"
+></iframe>
 <!-- End Widget -->`
 
 const EconomicCalendar = () => {
@@ -18,8 +19,8 @@ const EconomicCalendar = () => {
           미국 주요 경제 지표 (Investing.com 위젯)
         </h2>
         <p className="calendar-widget-description">
-          Investing.com에서 제공하는 미국(USD) 핵심 이벤트 달력을 직접 불러옵니다. 위젯이 보이지 않으면 Investing.com 공식 페이지에서
-          일정을 확인해 주세요.
+          Investing.com에서 제공하는 미국(USD) 핵심 이벤트 달력을 어두운 테마로 불러옵니다. 위젯이 보이지 않으면 Investing.com 공식
+          페이지에서 일정을 확인해 주세요.
         </p>
       </div>
       <div

--- a/src/components/MarketOverview.tsx
+++ b/src/components/MarketOverview.tsx
@@ -6,6 +6,7 @@ import {
   fetchBinanceQuotes,
   fetchFmpQuotes,
   fetchGateIoQuotes,
+  fetchInvestingQuotes,
   fetchStooqQuotes,
   fetchYahooQuotes,
 } from '../utils/marketData'
@@ -13,7 +14,7 @@ import { fallbackMarketNotice, fallbackMarketPrices } from '../utils/fallbackDat
 import type { PriceInfo } from '../utils/marketData'
 import { shouldUseLiveMarketData } from '../utils/liveDataFlags'
 
-const priceProviders = ['stooq', 'binance', 'gateio', 'fmp', 'yahoo'] as const
+const priceProviders = ['investing', 'stooq', 'binance', 'gateio', 'fmp', 'yahoo'] as const
 type PriceProvider = (typeof priceProviders)[number]
 
 const createProviderStatusState = (initial: 'idle' | 'loading' | 'error' = 'loading') =>
@@ -29,6 +30,7 @@ const createProviderMessageState = (initial: string | null = null) =>
   >
 
 const providerDisplayNames: Record<PriceProvider, string> = {
+  investing: 'Investing.com',
   stooq: 'Stooq',
   binance: 'Binance',
   gateio: 'Gate.io',
@@ -58,6 +60,7 @@ const assets: AssetConfig[] = [
     subtitle: '미국 기술주의 흐름을 가늠하는 대표 지수',
     chartSymbol: 'NASDAQ:IXIC',
     priceSources: [
+      { provider: 'investing', symbol: 'nasdaq-composite' },
       { provider: 'stooq', symbol: '^IXIC' },
       { provider: 'fmp', symbol: '^IXIC' },
       { provider: 'yahoo', symbol: '^IXIC' },
@@ -71,6 +74,7 @@ const assets: AssetConfig[] = [
     subtitle: '전통 우량주 중심의 벤치마크 지수',
     chartSymbol: 'DJI',
     priceSources: [
+      { provider: 'investing', symbol: 'dow-jones-30' },
       { provider: 'stooq', symbol: '^DJI' },
       { provider: 'fmp', symbol: '^DJI' },
       { provider: 'yahoo', symbol: '^DJI' },
@@ -153,6 +157,7 @@ const MarketOverview = () => {
       priceProviders.map((provider) => [provider, Array.from(symbolSets[provider])])
     ) as Record<PriceProvider, string[]>
   }, [])
+  const investingSymbols = providerSymbols.investing
   const binanceSymbols = providerSymbols.binance
   const gateIoSymbols = providerSymbols.gateio
   const fmpSymbols = providerSymbols.fmp
@@ -184,6 +189,9 @@ const MarketOverview = () => {
         promise: Promise<Record<string, PriceInfo>>
       }> = []
       const disabledProviders: PriceProvider[] = []
+      if (investingSymbols.length) {
+        tasks.push({ provider: 'investing', promise: fetchInvestingQuotes(investingSymbols) })
+      }
       if (binanceSymbols.length) {
         tasks.push({ provider: 'binance', promise: fetchBinanceQuotes(binanceSymbols) })
       }
@@ -410,6 +418,7 @@ const MarketOverview = () => {
     fmpApiKey,
     fmpSymbols,
     gateIoSymbols,
+    investingSymbols,
     stooqSymbols,
     useLiveMarketData,
     yahooSymbols,


### PR DESCRIPTION
## Summary
- update the embedded Investing.com 경제 캘린더 위젯 to use the dark theme, Korean localization, and sizing that matches the surrounding table layout
- refresh the calendar container styling so the iframe background integrates with the app's dark design on both desktop and mobile
- source NASDAQ and Dow Jones quotes from Investing.com first with resilient parsing, while keeping existing providers as fallbacks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d490cc41588326ad1fbe7ab45f7e56