### PR TITLE
Replace economic calendar widget with dark theme

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -734,141 +734,165 @@
 }
 
 .calendar-widget-card {
-  background: rgba(15, 23, 42, 0.65);
-  border: 1px solid rgba(148, 163, 184, 0.22);
-  border-radius: 18px;
-  padding: 1.25rem 1.35rem 1.4rem;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+}
+
+.ecal {
+  background: #0b0b0f;
+  color: #eaeaf0;
+  border-radius: 16px;
+  padding: 1.2rem;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(63, 63, 77, 0.6);
+}
+
+.ecal__header {
   display: flex;
-  flex-direction: column;
-  gap: 0.85rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03), 0 18px 45px rgba(15, 23, 42, 0.4);
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
 }
 
-.calendar-widget-title {
-  margin: 0 0 0.2rem;
-  font-size: 1.1rem;
-  font-weight: 700;
-  color: #f8fafc;
-}
-
-.calendar-widget-description {
+.ecal__header h2 {
   margin: 0;
-  color: rgba(148, 163, 184, 0.85);
-  line-height: 1.5;
+  font-size: 1.15rem;
+  color: #ffffff;
+}
+
+.ecal__controls {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.ecal__controls select,
+.ecal__controls button {
+  background: #15151c;
+  color: #eaeaf0;
+  border: 1px solid #2a2a36;
+  border-radius: 10px;
+  padding: 0.5rem 0.75rem;
   font-size: 0.9rem;
 }
 
-.calendar-widget-frame {
-  border-radius: 14px;
-  overflow: hidden;
-  background: #020617;
-  border: 1px solid rgba(71, 85, 105, 0.55);
-  position: relative;
-  min-height: 33.75rem;
+.ecal__controls button:hover:not(:disabled) {
+  background: #1b1b25;
 }
 
-.calendar-widget-frame iframe {
-  display: block;
+.ecal__controls button:disabled,
+.ecal__controls select:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.ecal__tablewrap {
+  overflow: auto;
+  border: 1px solid #1f1f2a;
+  border-radius: 12px;
+}
+
+.ecal__table {
   width: 100%;
-  border: 0;
-  min-height: 33.75rem;
-  background: #020617;
-  opacity: 0;
-  transition: opacity 0.35s ease;
+  border-collapse: separate;
+  border-spacing: 0;
 }
 
-@media (max-width: 640px) {
-  .calendar-widget-frame,
-  .calendar-widget-frame iframe {
-    min-height: 26rem;
-  }
+.ecal__table thead th {
+  position: sticky;
+  top: 0;
+  background: #101018;
+  color: #bfc5d1;
+  text-align: left;
+  font-weight: 600;
+  padding: 0.75rem;
+  border-bottom: 1px solid #1f1f2a;
+  font-size: 0.85rem;
 }
 
-.calendar-widget-frame--ready iframe {
-  opacity: 1;
+.ecal__table tbody td {
+  padding: 0.75rem;
+  border-bottom: 1px solid #1a1a24;
+  font-size: 0.88rem;
 }
 
-.calendar-widget-loader {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.85rem;
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.88));
-  color: rgba(226, 232, 240, 0.9);
-  font-size: 0.95rem;
+.ecal__table tbody tr:hover {
+  background: #13131b;
+}
+
+.ecal__empty {
   text-align: center;
-  padding: 1rem 1.2rem;
+  color: #98a2b3;
+  padding: 1.25rem 0;
 }
 
-.calendar-widget-spinner {
-  width: 34px;
-  height: 34px;
-  border-radius: 50%;
-  border: 3px solid rgba(96, 165, 250, 0.25);
-  border-top-color: #60a5fa;
-  animation: calendar-widget-spin 1s linear infinite;
-}
-
-@keyframes calendar-widget-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-.calendar-widget-footnote {
-  margin: 0;
-  font-size: 0.78rem;
-  color: rgba(148, 163, 184, 0.75);
-}
-
-.calendar-widget-footnote a {
-  color: #60a5fa;
-  font-weight: 600;
-  text-decoration: none;
-}
-
-.calendar-widget-footnote-hint {
-  display: block;
-  margin-top: 0.45rem;
-  color: rgba(226, 232, 240, 0.8);
-}
-
-.calendar-widget-footnote a:hover {
-  text-decoration: underline;
-}
-
-.impact-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  padding: 0.18rem 0.6rem;
+.pill {
+  display: inline-block;
+  padding: 0.15rem 0.6rem;
   border-radius: 999px;
-  font-size: 0.78rem;
+  font-size: 0.75rem;
   font-weight: 600;
 }
 
-.impact-high {
-  background: rgba(248, 113, 113, 0.25);
-  color: #fca5a5;
-  border: 1px solid rgba(239, 68, 68, 0.35);
+.pill--high {
+  background: #2a1212;
+  color: #ffb3b3;
+  border: 1px solid #5a1a1a;
 }
 
-.impact-medium {
-  background: rgba(251, 191, 36, 0.22);
-  color: #fcd34d;
-  border: 1px solid rgba(217, 119, 6, 0.35);
+.pill--med {
+  background: #1f1a12;
+  color: #ffd9a1;
+  border: 1px solid #5a4a1a;
 }
 
-.impact-low {
-  background: rgba(34, 197, 94, 0.22);
-  color: #86efac;
-  border: 1px solid rgba(34, 197, 94, 0.35);
+.pill--low {
+  background: #121f12;
+  color: #b9ffb3;
+  border: 1px solid #1a5a1a;
+}
+
+.ecal__value {
+  font-weight: 600;
+}
+
+.ecal__value.up {
+  color: #98ff98;
+}
+
+.ecal__value.down {
+  color: #ffa6a6;
+}
+
+.ecal__footer {
+  margin-top: 0.6rem;
+  color: #98a2b3;
+  font-size: 0.75rem;
+}
+
+@media (max-width: 720px) {
+  .ecal__table thead th:nth-child(4),
+  .ecal__table thead th:nth-child(5),
+  .ecal__table tbody td:nth-child(4),
+  .ecal__table tbody td:nth-child(5) {
+    display: none;
+  }
+
+  .ecal__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .ecal__controls {
+    width: 100%;
+  }
+
+  .ecal__controls select,
+  .ecal__controls button {
+    width: 100%;
+  }
 }
 
 .table-empty {

--- a/src/components/EconomicCalendar.tsx
+++ b/src/components/EconomicCalendar.tsx
@@ -1,38 +1,253 @@
-const INVESTING_ECONOMIC_CALENDAR_IFRAME = `<!-- Investing.com Economic Calendar Widget -->
-<iframe
-  src="https://sslecal2.investing.com?columns=exc_currency,exc_importance,exc_actual,exc_forecast,exc_previous&importance=3&country=5&calType=day&timeZone=8&theme=dark&lang=24"
-  width="100%"
-  height="540"
-  frameborder="0"
-  allowtransparency="true"
-  style="background:#020617;color:#e2e8f0;"
-  marginwidth="0"
-  marginheight="0"
-></iframe>
-<!-- End Widget -->`
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+type RangeOption = 'day' | 'week'
+
+type TradingEconomicsEvent = {
+  DateUTC?: string
+  Date?: string
+  Country?: string
+  Event?: string
+  EventName?: string
+  Actual?: string
+  Forecast?: string
+  Previous?: string
+  Importance?: number
+  Impact?: number
+}
+
+type CalendarRow = {
+  id: string
+  timeLabel: string
+  title: string
+  actual: string
+  actualTone: 'up' | 'down' | null
+  forecast: string
+  previous: string
+  importance: number
+}
+
+const COUNTRY = 'united states'
+const IMPORTANCE = 3
+const TZ_OFFSET = 9
+const API_KEY = 'guest:guest'
+const BASE_URL = 'https://api.tradingeconomics.com/calendar'
+
+const formatDate = (date: Date) => date.toISOString().slice(0, 10)
+
+const getRange = (type: RangeOption) => {
+  const now = new Date()
+  const start = new Date(now)
+  const end = new Date(now)
+
+  if (type === 'week') {
+    const day = (now.getDay() + 6) % 7 // Monday = 0
+    start.setDate(now.getDate() - day)
+    end.setDate(start.getDate() + 6)
+  }
+
+  start.setHours(0, 0, 0, 0)
+  end.setHours(23, 59, 59, 999)
+
+  return { d1: formatDate(start), d2: formatDate(end) }
+}
+
+const toKSTDate = (iso?: string) => {
+  if (!iso) return null
+  const parsed = new Date(iso)
+  if (Number.isNaN(parsed.getTime())) return null
+  return new Date(parsed.getTime() + TZ_OFFSET * 60 * 60 * 1000)
+}
+
+const formatKSTLabel = (iso?: string) => {
+  const date = toKSTDate(iso)
+  if (!date) return '—'
+
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+
+  return `${month}/${day} ${hours}:${minutes}`
+}
+
+const pillClass = (importance: number) => {
+  if (importance >= 3) return 'pill pill--high'
+  if (importance === 2) return 'pill pill--med'
+  return 'pill pill--low'
+}
+
+const sanitize = (value?: string | number | null) => {
+  if (value === null || value === undefined || value === '') return '—'
+  return String(value)
+}
+
+const detectTone = (value: string) => {
+  if (!value || value === '—') return null
+  if (/[+▲↑]/.test(value) && !/[-▼↓]/.test(value)) return 'up'
+  if (/-|[▼↓]/.test(value)) return 'down'
+  return null
+}
 
 const EconomicCalendar = () => {
+  const [range, setRange] = useState<RangeOption>('week')
+  const [loading, setLoading] = useState<boolean>(false)
+  const [error, setError] = useState<string | null>(null)
+  const [events, setEvents] = useState<CalendarRow[]>([])
+  const [refreshIndex, setRefreshIndex] = useState(0)
+
+  const fetchCalendar = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+
+    const { d1, d2 } = getRange(range)
+    const params = new URLSearchParams({
+      country: COUNTRY,
+      importance: String(IMPORTANCE),
+      d1,
+      d2,
+      c: API_KEY,
+    })
+
+    try {
+      const response = await fetch(`${BASE_URL}?${params.toString()}`)
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`)
+      }
+
+      const data: TradingEconomicsEvent[] = await response.json()
+      const rows = (data ?? [])
+        .filter((item) => (item.Country ?? '').toLowerCase().includes(COUNTRY))
+        .sort((a, b) => {
+          const aDate = new Date(a.DateUTC ?? a.Date ?? 0).getTime()
+          const bDate = new Date(b.DateUTC ?? b.Date ?? 0).getTime()
+          return aDate - bDate
+        })
+        .map<CalendarRow>((item, index) => {
+          const timeLabel = formatKSTLabel(item.DateUTC ?? item.Date)
+          const actual = sanitize(item.Actual)
+          const forecast = sanitize(item.Forecast)
+          const previous = sanitize(item.Previous)
+          const importance = Number(item.Importance ?? item.Impact ?? 0)
+          return {
+            id: `${item.DateUTC ?? item.Date ?? 'unknown'}-${item.Event ?? item.EventName ?? index}`,
+            timeLabel,
+            title: sanitize(item.Event ?? item.EventName ?? '—'),
+            actual,
+            actualTone: detectTone(actual),
+            forecast,
+            previous,
+            importance,
+          }
+        })
+
+      setEvents(rows)
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message.includes('Failed to fetch') ? '네트워크 또는 CORS 설정을 확인해주세요.' : err.message)
+      } else {
+        setError('알 수 없는 오류가 발생했습니다.')
+      }
+      setEvents([])
+    } finally {
+      setLoading(false)
+    }
+  }, [range])
+
+  useEffect(() => {
+    fetchCalendar()
+  }, [fetchCalendar, refreshIndex])
+
+  const bodyContent = useMemo(() => {
+    if (loading) {
+      return (
+        <tr>
+          <td colSpan={6} className="ecal__empty">
+            로딩 중…
+          </td>
+        </tr>
+      )
+    }
+
+    if (error) {
+      return (
+        <tr>
+          <td colSpan={6} className="ecal__empty">
+            데이터를 불러오지 못했습니다. {error}
+          </td>
+        </tr>
+      )
+    }
+
+    if (events.length === 0) {
+      return (
+        <tr>
+          <td colSpan={6} className="ecal__empty">
+            표시할 이벤트가 없습니다.
+          </td>
+        </tr>
+      )
+    }
+
+    return events.map((event) => (
+      <tr key={event.id}>
+        <td>{event.timeLabel}</td>
+        <td>{event.title}</td>
+        <td className={event.actualTone ? `ecal__value ${event.actualTone}` : undefined}>{event.actual}</td>
+        <td>{event.forecast}</td>
+        <td>{event.previous}</td>
+        <td>
+          <span className={pillClass(event.importance)}>
+            {event.importance >= 3 ? '높음' : event.importance === 2 ? '보통' : '낮음'}
+          </span>
+        </td>
+      </tr>
+    ))
+  }, [events, error, loading])
+
   return (
     <section className="calendar-widget-card" aria-labelledby="economic-calendar-heading">
-      <div>
-        <h2 id="economic-calendar-heading" className="calendar-widget-title">
-          미국 주요 경제 지표 (Investing.com 위젯)
-        </h2>
-        <p className="calendar-widget-description">
-          Investing.com에서 제공하는 미국(USD) 핵심 이벤트 달력을 어두운 테마로 불러옵니다. 위젯이 보이지 않으면 Investing.com 공식
-          페이지에서 일정을 확인해 주세요.
-        </p>
+      <div className="ecal" id="usd-calendar">
+        <header className="ecal__header">
+          <h2 id="economic-calendar-heading">미국 경제지표 캘린더</h2>
+          <div className="ecal__controls">
+            <label htmlFor="calendar-range" className="visually-hidden">
+              조회 범위 선택
+            </label>
+            <select
+              id="calendar-range"
+              value={range}
+              onChange={(event) => setRange(event.target.value as RangeOption)}
+              disabled={loading}
+            >
+              <option value="day">오늘</option>
+              <option value="week">이번 주</option>
+            </select>
+            <button type="button" onClick={() => setRefreshIndex((value) => value + 1)} disabled={loading}>
+              {loading ? '새로고침 중…' : '새로고침'}
+            </button>
+          </div>
+        </header>
+
+        <div className="ecal__tablewrap">
+          <table className="ecal__table">
+            <thead>
+              <tr>
+                <th scope="col">시간 (KST)</th>
+                <th scope="col">지표</th>
+                <th scope="col">실제</th>
+                <th scope="col">예상</th>
+                <th scope="col">이전</th>
+                <th scope="col">중요도</th>
+              </tr>
+            </thead>
+            <tbody>{bodyContent}</tbody>
+          </table>
+        </div>
+
+        <footer className="ecal__footer">
+          <small>Source: Trading Economics</small>
+        </footer>
       </div>
-      <div
-        className="calendar-widget-frame calendar-widget-frame--ready"
-        dangerouslySetInnerHTML={{ __html: INVESTING_ECONOMIC_CALENDAR_IFRAME }}
-      />
-      <p className="calendar-widget-footnote">
-        데이터 제공:{' '}
-        <a href="https://www.investing.com/economic-calendar/" target="_blank" rel="noreferrer">
-          Investing.com 경제 캘린더
-        </a>
-      </p>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- replace the Investing.com iframe with a custom TradingEconomics-powered economic calendar that renders a dark theme table in React
- add interactive range selection, refresh handling, and status messaging for loading, empty, and error states
- style the new widget to match the dark palette with responsive table behavior on smaller screens

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4a2fc630483269ef372281a8bdfe2