### PR TITLE
feat: integrate live trading economics calendar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -757,6 +757,12 @@
   margin-bottom: 1rem;
 }
 
+.ecal__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
 .ecal__header h2 {
   margin: 0;
   font-size: 1.15rem;
@@ -766,6 +772,9 @@
 .ecal__controls {
   display: flex;
   gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
 }
 
 .ecal__controls select,
@@ -776,6 +785,52 @@
   border-radius: 10px;
   padding: 0.5rem 0.75rem;
   font-size: 0.9rem;
+}
+
+.ecal__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.ecal__filter-btn {
+  background: #15151c;
+  border: 1px solid #2a2a36;
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #cbd5f5;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.ecal__filter-btn:hover,
+.ecal__filter-btn:focus-visible {
+  background: #1b1b25;
+  border-color: #3a3a4a;
+  outline: none;
+}
+
+.ecal__filter-btn[aria-pressed='true'] {
+  background: #1f2a44;
+  border-color: #3e5caa;
+  color: #eff6ff;
+  box-shadow: inset 0 0 0 1px rgba(148, 197, 255, 0.35);
+}
+
+.ecal__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.75rem;
+  font-size: 0.78rem;
+  color: #98a2b3;
+}
+
+.ecal__meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 .ecal__controls button:hover:not(:disabled) {
@@ -854,6 +909,12 @@
   border: 1px solid #1a5a1a;
 }
 
+.pill--none {
+  background: #1a1a24;
+  color: #cbd5f5;
+  border: 1px solid #2a2a36;
+}
+
 .ecal__value {
   font-weight: 600;
 }
@@ -872,6 +933,43 @@
   font-size: 0.75rem;
 }
 
+.ecal__title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.ecal__title-link {
+  color: #f8fafc;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.ecal__title-link:hover,
+.ecal__title-link:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}
+
+.ecal__title-text {
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.ecal__title-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem 0.6rem;
+  font-size: 0.72rem;
+  color: #9ca3af;
+}
+
+.ecal__title-meta span {
+  background: rgba(31, 31, 42, 0.8);
+  border-radius: 999px;
+  padding: 0.18rem 0.55rem;
+}
+
 @media (max-width: 720px) {
   .ecal__table thead th:nth-child(4),
   .ecal__table thead th:nth-child(5),
@@ -887,11 +985,17 @@
 
   .ecal__controls {
     width: 100%;
+    justify-content: flex-start;
   }
 
   .ecal__controls select,
   .ecal__controls button {
     width: 100%;
+  }
+
+  .ecal__filters {
+    width: 100%;
+    justify-content: flex-start;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the placeholder economic calendar with data fetched from the Trading Economics proxy API
- add importance-level filters, richer event metadata, and cache/status indicators to the calendar widget
- refresh the calendar styles for the new controls and detail chips

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4a7d853dc83268da39f72f27f4ead