### PR TITLE
Add serverless consultation HTML sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ npm run build        # 프로덕션 빌드 생성
 npm run preview      # 빌드 검증
 ```
 
+## 서버리스 투자 상담 창구 샘플
+
+프론트엔드 프로젝트와 별개로, 온디바이스 LLM(WebLLM)과 FormSubmit을 이용해 **추가 서버 없이 동작하는 상담 창구 HTML 샘플**을 제공합니다.
+
+- 위치: [`public/consultation.html`](public/consultation.html)
+- 구성: 주간 미국 경제지표 위젯, 온디바이스 투자 Q&A, FormSubmit 기반 문의 메일 폼
+- 사용 방법: 파일을 그대로 배포하거나 브라우저에서 열면 됩니다. 메일 전송 주소만 본인 주소로 교체하세요.
+
 ## 주의 사항
 
 - 외부 API의 CORS 정책이나 호출 제한에 따라 데이터 로드가 지연되거나 실패할 수 있습니다.

--- a/public/consultation.html
+++ b/public/consultation.html
@@ -1,0 +1,214 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>투자상담 창구 (서버리스/무료)</title>
+<style>
+  :root{--bg:#0b0b0f;--panel:#13131b;--muted:#98a2b3;--text:#eaeaf0;--accent:#6ea8fe;--border:#1f1f2a;}
+  body{margin:0;background:var(--bg);color:var(--text);font-family:ui-sans-serif,system-ui,Segoe UI,Roboto,Apple SD Gothic Neo,Apple Color Emoji,Segoe UI Emoji;}
+  .wrap{max-width:980px;margin:32px auto;padding:0 16px;display:grid;gap:20px}
+  .card{background:var(--panel);border:1px solid var(--border);border-radius:14px;box-shadow:0 6px 18px rgba(0,0,0,.35)}
+  .card h2{margin:0;padding:14px 16px;border-bottom:1px solid var(--border);font-size:18px}
+  .card .body{padding:16px}
+  .row{display:flex;gap:8px}
+  input,textarea,select,button{background:#15151c;color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px;font-size:14px}
+  textarea{min-height:110px;resize:vertical}
+  button{cursor:pointer}
+  button.primary{background:#1b1b25;border-color:#2a2a36}
+  button.primary:hover{background:#20202b}
+  .muted{color:var(--muted)}
+  .pill{display:inline-block;padding:2px 8px;border-radius:999px;border:1px solid var(--border);font-size:12px;color:var(--muted)}
+  .chat{display:flex;flex-direction:column;gap:10px}
+  .msg{padding:10px 12px;border:1px solid var(--border);border-radius:12px;max-width:90%}
+  .msg.user{align-self:flex-end;background:#101018}
+  .msg.bot{align-self:flex-start;background:#0e0e16}
+  .small{font-size:12px}
+  .right{float:right}
+  .mt8{margin-top:8px}
+  .tablewrap{overflow:auto;border:1px solid var(--border);border-radius:10px}
+  iframe{display:block;border:0;width:100%}
+</style>
+</head>
+<body>
+  <div class="wrap">
+
+    <!-- 1) 주간 미국 경제지표 (Investing.com iframe) -->
+    <section class="card">
+      <h2>미국 경제지표 (이번 주 · KST)</h2>
+      <div class="body">
+        <div class="tablewrap">
+          <iframe 
+            src="https://sslecal2.investing.com?columns=exc_currency,exc_importance,exc_actual,exc_forecast,exc_previous&importance=3&country=5&calType=week&timeZone=9" 
+            height="600"
+            loading="lazy"
+            title="Investing.com Economic Calendar (US, week)">
+          </iframe>
+        </div>
+        <p class="small muted mt8">위젯 내부 색상은 제공사 정책상 변경 불가. 페이지 배경은 다크 테마로 통일했습니다.</p>
+      </div>
+    </section>
+
+    <!-- 2) 투자상담 Q&A (브라우저 내 LLM: WebLLM) -->
+    <section class="card" id="qa">
+      <h2>투자상담 · 질의응답 (서버/토큰 불필요)</h2>
+      <div class="body">
+        <div class="row">
+          <input id="q" type="text" placeholder="질문을 입력하세요 (예: 이번 주 CPI 발표가 시장에 미칠 영향은?)" style="flex:1" />
+          <button id="ask" class="primary">보내기</button>
+        </div>
+        <div id="status" class="small muted mt8">모델 로딩 중… 처음 1~2분 정도 걸릴 수 있어요(한번 로딩되면 이후엔 빠릅니다).</div>
+        <div id="chat" class="chat mt8" aria-live="polite"></div>
+        <div class="small muted mt8">
+          <span class="pill">온디바이스 LLM</span>
+          <span class="pill">Llama 3.2 1B-Instruct (Q4)</span>
+          <span class="pill">네트워크 없이 동작</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- 3) 투자상담 메일 보내기 (FormSubmit 무료) -->
+    <section class="card">
+      <h2>문의 메일 보내기 (서버리스)</h2>
+      <div class="body">
+        <!-- ✅ 아래 action 이메일만 본인 주소로 교체하세요 -->
+        <form id="contact" action="https://formsubmit.co/jh2soft@naver.com" method="POST">
+          <!-- FormSubmit 옵션 -->
+          <input type="hidden" name="_subject" value="[투자상담] 웹 문의" />
+          <input type="hidden" name="_captcha" value="false" />
+          <input type="hidden" name="_template" value="table" />
+          <!-- 제출 후 이동 페이지(원치 않으면 제거) -->
+          <input type="hidden" name="_next" value="" />
+
+          <div class="row">
+            <input name="name" placeholder="이름" required style="flex:1" />
+            <input name="email" type="email" placeholder="이메일" required style="flex:1" />
+          </div>
+          <input name="subject" placeholder="제목" required style="width:100%;margin-top:8px" />
+          <textarea name="message" placeholder="문의 내용을 자세히 작성해주세요 (20자 이상)" minlength="20" required style="width:100%;margin-top:8px"></textarea>
+          <div class="row" style="justify-content:flex-end">
+            <button class="primary" type="submit">메일 보내기</button>
+          </div>
+          <p class="small muted mt8">* 첫 제출 시 FormSubmit에서 본인 메일 인증 요청이 갈 수 있어요(스팸 방지).</p>
+        </form>
+      </div>
+    </section>
+
+  </div>
+
+  <!-- WebLLM (브라우저 내 추론) -->
+  <script src="https://unpkg.com/@mlc-ai/web-llm@0.2.61/dist/index.js"></script>
+  <script>
+    // ===== Q&A: WebLLM 온디바이스 모델 =====
+    const chatEl = document.getElementById('chat');
+    const statusEl = document.getElementById('status');
+    const askBtn = document.getElementById('ask');
+    const qInput = document.getElementById('q');
+
+    // 가벼운 모델(무료/로컬) - 처음 로딩에 다소 시간 필요
+    const model = {
+      model_id: "Llama-3.2-1B-Instruct-q4f16_1-MLC",
+      // 더 정확도가 필요하면 3B 모델로 교체 가능(성능/메모리 ↑)
+      // model_id: "Llama-3.1-3B-Instruct-q4f16_1-MLC",
+    };
+
+    const chatHist = []; // 최근 대화(간단 저장)
+
+    let engine;
+    (async () => {
+      try{
+        engine = await webllm.CreateMLCEngine(model, {
+          initProgressCallback: (report) => {
+            statusEl.textContent = `모델 준비 중: ${report.text} (${Math.round((report.progress||0)*100)}%)`;
+          }
+        });
+        statusEl.textContent = "모델 준비 완료. 질문을 입력해 보세요!";
+      }catch(e){
+        statusEl.textContent = "모델 로딩 실패: " + e.message;
+      }
+    })();
+
+    function pushMsg(role, text){
+      const el = document.createElement('div');
+      el.className = 'msg ' + (role === 'user' ? 'user' : 'bot');
+      el.innerText = text;
+      chatEl.appendChild(el);
+      el.scrollIntoView({behavior:'smooth', block:'end'});
+    }
+
+    async function ask(){
+      const q = qInput.value.trim();
+      if(!q) return;
+      if(!engine){ alert('모델이 아직 준비되지 않았어요. 잠시만요!'); return; }
+
+      pushMsg('user', q);
+      qInput.value = ''; qInput.focus();
+
+      const sysPrompt =
+        "당신은 투자상담 도우미입니다. 최신 데이터가 필요할 경우 '실시간 데이터가 필요합니다'라고 명확히 고지하고, " +
+        "일반적 원리/개념/리스크 경고와 함께 보수적으로 답하세요. 개인 맞춤 투자 조언은 피하고 정보 제공만 하세요.";
+
+      statusEl.textContent = "답변 생성 중…";
+      askBtn.disabled = true;
+
+      try{
+        const messages = [
+          { role: "system", content: sysPrompt },
+          ...chatHist,
+          { role: "user", content: q }
+        ];
+        const reply = await engine.chat.completions.create({
+          messages, temperature: 0.7, max_tokens: 512, stream: true
+        });
+
+        let buf = "";
+        for await (const chunk of reply){
+          const delta = chunk.choices?.[0]?.delta?.content || "";
+          if(delta){
+            buf += delta;
+            // 실시간 스트리밍 렌더
+            if(!document.getElementById('streaming')){
+              const el = document.createElement('div');
+              el.id = 'streaming';
+              el.className = 'msg bot';
+              chatEl.appendChild(el);
+            }
+            document.getElementById('streaming').innerText = buf;
+            document.getElementById('streaming').scrollIntoView({behavior:'smooth', block:'end'});
+          }
+        }
+        // 스트림 마무리
+        const s = document.getElementById('streaming');
+        if(s){ s.removeAttribute('id'); }
+
+        chatHist.push({ role: "user", content: q }, { role: "assistant", content: buf });
+        statusEl.textContent = "완료";
+      }catch(e){
+        statusEl.textContent = "생성 실패: " + e.message;
+        pushMsg('bot', "죄송해요, 답변 생성에 실패했습니다. 질문을 조금 더 구체적으로 적어볼까요?");
+      }finally{
+        askBtn.disabled = false;
+      }
+    }
+
+    askBtn.addEventListener('click', ask);
+    qInput.addEventListener('keydown', (ev)=>{ if(ev.key==='Enter'){ ask(); } });
+
+    // ===== 메일 폼 UX(선제 검증) =====
+    const contactForm = document.getElementById('contact');
+    contactForm.addEventListener('submit', (e)=>{
+      const form = e.target;
+      const msg = form.querySelector('textarea[name="message"]').value || "";
+      if(msg.trim().length < 20){
+        e.preventDefault();
+        alert("문의 내용을 20자 이상 작성해주세요.");
+        return false;
+      }
+      // 전송 UX
+      const btn = form.querySelector('button[type="submit"]');
+      btn.disabled = true; btn.textContent = "전송 중…";
+      setTimeout(()=>{ btn.disabled = false; btn.textContent = "메일 보내기"; }, 5000); // FormSubmit 응답 후 자동 리다이렉트
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone public/consultation.html page that embeds the economic calendar widget, WebLLM Q&A, and FormSubmit mail form for zero-cost deployment
- document the new serverless consultation sample in the README with usage instructions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4ab32d8b08326b9c0080ca6a2a45b