### PR TITLE
Integrate consultation assistant widgets into main page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1453,6 +1453,237 @@
   outline: none;
 }
 
+.consultation-suite {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 1024px) {
+  .consultation-suite {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.consultation-ai,
+.consultation-mail {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.consultation-ai-header h2,
+.consultation-mail-header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+  color: #f8fafc;
+}
+
+.consultation-ai-header p,
+.consultation-mail-header p {
+  margin: 0.35rem 0 0;
+  color: rgba(226, 232, 240, 0.75);
+  line-height: 1.6;
+}
+
+.consultation-ai-form {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.consultation-ai-form input {
+  flex: 1 1 auto;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+  color: #e2e8f0;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.consultation-ai-form input:focus {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.6);
+  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.25);
+}
+
+.consultation-ai-form button {
+  flex: 0 0 auto;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.9), rgba(59, 130, 246, 0.75));
+  border: none;
+  border-radius: 12px;
+  color: #f8fafc;
+  font-weight: 600;
+  padding: 0.85rem 1.5rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.consultation-ai-form button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.consultation-ai-form button:not(:disabled):hover,
+.consultation-ai-form button:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(37, 99, 235, 0.3);
+  outline: none;
+}
+
+.consultation-ai-status {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.consultation-ai-chat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  max-height: 420px;
+  overflow-y: auto;
+  padding-right: 0.35rem;
+}
+
+.consultation-ai-message {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-width: 88%;
+  padding: 0.8rem 1rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.35);
+  color: #e2e8f0;
+  line-height: 1.6;
+}
+
+.consultation-ai-message-user {
+  align-self: flex-end;
+  background: rgba(30, 64, 175, 0.4);
+  border-color: rgba(59, 130, 246, 0.45);
+}
+
+.consultation-ai-message-assistant {
+  align-self: flex-start;
+}
+
+.consultation-ai-message-streaming {
+  border-style: dashed;
+  opacity: 0.85;
+}
+
+.consultation-ai-message-role {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.consultation-ai-message p {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.consultation-ai-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.consultation-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.consultation-mail-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.consultation-mail-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.consultation-mail-form input,
+.consultation-mail-form textarea {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+  color: #e2e8f0;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.consultation-mail-form textarea {
+  min-height: 140px;
+  resize: vertical;
+}
+
+.consultation-mail-form input:focus,
+.consultation-mail-form textarea:focus {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.6);
+  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.25);
+}
+
+.consultation-mail-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.consultation-mail-submit {
+  background: rgba(15, 118, 255, 0.85);
+  border: none;
+  border-radius: 12px;
+  color: #f8fafc;
+  font-weight: 600;
+  padding: 0.85rem 1.75rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.consultation-mail-submit:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.consultation-mail-submit:not(:disabled):hover,
+.consultation-mail-submit:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(15, 118, 255, 0.35);
+  outline: none;
+}
+
+.consultation-mail-note {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.consultation-mail-helper {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
 .footer {
   margin-top: auto;
   text-align: center;
@@ -1575,5 +1806,26 @@
 
   .consultation-refresh {
     width: 100%;
+  }
+
+  .consultation-suite {
+    grid-template-columns: 1fr;
+  }
+
+  .consultation-ai-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .consultation-ai-form button {
+    width: 100%;
+  }
+
+  .consultation-ai-message {
+    max-width: 100%;
+  }
+
+  .consultation-mail-row {
+    flex-direction: column;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import ExchangeRateTicker from './components/ExchangeRateTicker'
 import MarketOverview from './components/MarketOverview'
 import NewsFeed from './components/NewsFeed'
 import ConsultationBoard from './components/ConsultationBoard'
+import ConsultationChat from './components/ConsultationChat'
+import ConsultationMailForm from './components/ConsultationMailForm'
 
 function App() {
   return (
@@ -32,6 +34,11 @@ function App() {
         </main>
 
         <ConsultationBoard />
+
+        <div className="consultation-suite">
+          <ConsultationChat />
+          <ConsultationMailForm />
+        </div>
 
         <footer className="footer">
           © {new Date().getFullYear()} JH Investment Lab · 데이터 출처: Investing.com, Binance, Financial Modeling

--- a/src/components/ConsultationChat.tsx
+++ b/src/components/ConsultationChat.tsx
@@ -1,0 +1,299 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import type { WebLLM, WebLLMEngine } from '../types/webllm'
+
+const WEB_LLM_SCRIPT_URL = 'https://unpkg.com/@mlc-ai/web-llm@0.2.61/dist/index.js'
+const MODEL_ID = 'Llama-3.2-1B-Instruct-q4f16_1-MLC'
+const SYSTEM_PROMPT =
+  "당신은 투자상담 도우미입니다. 최신 데이터가 필요할 경우 '실시간 데이터가 필요합니다'라고 명확히 고지하고, " +
+  '일반적 원리/개념/리스크 경고와 함께 보수적으로 답하세요. 개인 맞춤 투자 조언은 피하고 정보 제공만 하세요.'
+
+type ChatMessage = {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+}
+
+type ProgressState = {
+  text?: string
+  progress?: number
+}
+
+let webLlmLoader: Promise<WebLLM | undefined> | null = null
+
+const loadWebLLM = () => {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('브라우저 환경에서만 사용할 수 있습니다.'))
+  }
+
+  if (window.webllm) {
+    return Promise.resolve(window.webllm)
+  }
+
+  if (webLlmLoader) {
+    return webLlmLoader
+  }
+
+  webLlmLoader = new Promise<WebLLM | undefined>((resolve, reject) => {
+    const existingScript = document.querySelector<HTMLScriptElement>(`script[src="${WEB_LLM_SCRIPT_URL}"]`)
+
+    const handleResolve = () => {
+      if (window.webllm) {
+        resolve(window.webllm)
+      } else {
+        reject(new Error('WebLLM 라이브러리를 초기화하지 못했습니다.'))
+      }
+    }
+
+    const handleError = () => {
+      webLlmLoader = null
+      reject(new Error('WebLLM 스크립트를 불러오지 못했습니다.'))
+    }
+
+    if (existingScript) {
+      existingScript.addEventListener('load', handleResolve, { once: true })
+      existingScript.addEventListener('error', handleError, { once: true })
+      return
+    }
+
+    const script = document.createElement('script')
+    script.src = WEB_LLM_SCRIPT_URL
+    script.async = true
+    script.addEventListener('load', handleResolve, { once: true })
+    script.addEventListener('error', handleError, { once: true })
+    document.head.appendChild(script)
+  })
+
+  return webLlmLoader
+}
+
+const createMessageId = (prefix: string) => `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+
+const ConsultationChat = () => {
+  const [question, setQuestion] = useState('')
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const engineRef = useRef<WebLLMEngine | null>(null)
+  const streamingRef = useRef(false)
+  const [streamingContent, setStreamingContent] = useState<string | null>(null)
+  const [status, setStatus] = useState('모델 로딩 중… 처음 1~2분 정도 걸릴 수 있어요(한번 로딩되면 이후엔 빠릅니다).')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [asking, setAsking] = useState(false)
+
+  useEffect(() => {
+    let isCancelled = false
+    let localEngine: WebLLMEngine | null = null
+
+    const initialize = async () => {
+      try {
+        const webllm = await loadWebLLM()
+        if (isCancelled) {
+          return
+        }
+
+        if (!webllm) {
+          throw new Error('WebLLM 엔진을 찾을 수 없습니다.')
+        }
+
+        const engine = await webllm.CreateMLCEngine(
+          { model_id: MODEL_ID },
+          {
+            initProgressCallback: (report: ProgressState) => {
+              if (isCancelled) {
+                return
+              }
+              const percent = typeof report.progress === 'number' ? `${Math.round(report.progress * 100)}%` : ''
+              setStatus(`모델 준비 중: ${report.text ?? ''}${percent ? ` (${percent})` : ''}`.trim())
+            },
+          },
+        )
+
+        if (isCancelled) {
+          engine.dispose?.()
+          return
+        }
+
+        engineRef.current = engine
+        localEngine = engine
+        setStatus('모델 준비 완료. 질문을 입력해 보세요!')
+        setLoading(false)
+        setError(null)
+      } catch (initError) {
+        console.error('WebLLM 초기화 실패', initError)
+        if (isCancelled) {
+          return
+        }
+        setError('모델 로딩에 실패했습니다. 네트워크 연결을 확인한 뒤 새로고침해 주세요.')
+        setStatus('모델을 불러오지 못했습니다.')
+        setLoading(false)
+      }
+    }
+
+    initialize().catch((initError) => {
+      console.error(initError)
+    })
+
+    return () => {
+      isCancelled = true
+      streamingRef.current = false
+      if (localEngine) {
+        try {
+          localEngine.interruptGenerate?.()
+          localEngine.dispose?.()
+        } catch (disposeError) {
+          console.error('WebLLM 엔진 정리 실패', disposeError)
+        }
+      }
+    }
+  }, [])
+
+  const conversation = useMemo(
+    () => messages.map(({ role, content }) => ({ role, content })),
+    [messages],
+  )
+
+  const handleAsk = useCallback(async () => {
+    const trimmed = question.trim()
+    if (!trimmed) {
+      return
+    }
+
+    if (!engineRef.current) {
+      setStatus('모델이 아직 준비되지 않았어요. 잠시만 기다려 주세요!')
+      return
+    }
+
+    setQuestion('')
+    setAsking(true)
+    setError(null)
+
+    const userMessage: ChatMessage = { id: createMessageId('user'), role: 'user', content: trimmed }
+    setMessages((prev) => [...prev, userMessage])
+    setStatus('답변 생성 중…')
+
+    const payload = [
+      { role: 'system', content: SYSTEM_PROMPT },
+      ...conversation,
+      { role: 'user', content: trimmed },
+    ]
+
+    try {
+      streamingRef.current = true
+      setStreamingContent('')
+      const reply = await engineRef.current.chat.completions.create({
+        messages: payload,
+        temperature: 0.7,
+        max_tokens: 512,
+        stream: true,
+      })
+
+      let buffer = ''
+      for await (const chunk of reply) {
+        if (!streamingRef.current) {
+          break
+        }
+        const delta = chunk?.choices?.[0]?.delta?.content ?? ''
+        if (!delta) {
+          continue
+        }
+        buffer += delta
+        setStreamingContent(buffer)
+      }
+
+      streamingRef.current = false
+      setStreamingContent(null)
+
+      const cleaned = buffer.trim()
+      if (cleaned) {
+        const assistantMessage: ChatMessage = {
+          id: createMessageId('assistant'),
+          role: 'assistant',
+          content: cleaned,
+        }
+        setMessages((prev) => [...prev, assistantMessage])
+        setStatus('완료')
+      } else {
+        setStatus('답변을 생성하지 못했습니다. 질문을 조금 더 구체적으로 적어볼까요?')
+      }
+    } catch (askError) {
+      console.error('WebLLM 응답 실패', askError)
+      streamingRef.current = false
+      setStreamingContent(null)
+      setStatus('생성 실패: 다시 시도해 주세요.')
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: createMessageId('assistant-error'),
+          role: 'assistant',
+          content: '죄송해요, 답변 생성에 실패했습니다. 질문을 조금 더 구체적으로 적어볼까요?',
+        },
+      ])
+    } finally {
+      setAsking(false)
+    }
+  }, [conversation, question])
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      if (asking) {
+        return
+      }
+      void handleAsk()
+    },
+    [asking, handleAsk],
+  )
+
+  return (
+    <section className="section consultation-ai" aria-labelledby="consultation-ai-heading">
+      <div className="consultation-ai-header">
+        <h2 id="consultation-ai-heading">투자상담 · 질의응답 (서버/토큰 불필요)</h2>
+        <p>
+          브라우저에서 직접 실행되는 온디바이스 LLM으로 간단한 투자 Q&amp;A를 도와드립니다. 실시간 시세 등 최신 데이터가 필요한
+          경우에는 별도로 안내해 드려요.
+        </p>
+      </div>
+
+      <form className="consultation-ai-form" onSubmit={handleSubmit}>
+        <input
+          type="text"
+          value={question}
+          onChange={(event) => setQuestion(event.target.value)}
+          placeholder="질문을 입력하세요 (예: 이번 주 CPI 발표가 시장에 미칠 영향은?)"
+          disabled={loading || asking || Boolean(error)}
+          aria-label="투자 관련 질문 입력"
+        />
+        <button type="submit" disabled={loading || asking || Boolean(error)}>
+          {asking ? '생성 중…' : '보내기'}
+        </button>
+      </form>
+
+      <p className="consultation-ai-status" role="status">
+        {error ?? status}
+      </p>
+
+      <div className="consultation-ai-chat" aria-live="polite">
+        {messages.map((message) => (
+          <div key={message.id} className={`consultation-ai-message consultation-ai-message-${message.role}`}>
+            <span className="consultation-ai-message-role">{message.role === 'user' ? '나' : '도우미'}</span>
+            <p>{message.content}</p>
+          </div>
+        ))}
+        {streamingContent !== null && (
+          <div className="consultation-ai-message consultation-ai-message-assistant consultation-ai-message-streaming">
+            <span className="consultation-ai-message-role">도우미</span>
+            <p>{streamingContent}</p>
+          </div>
+        )}
+      </div>
+
+      <div className="consultation-ai-meta">
+        <span className="consultation-pill">온디바이스 LLM</span>
+        <span className="consultation-pill">Llama 3.2 1B-Instruct (Q4)</span>
+        <span className="consultation-pill">네트워크 없이 동작</span>
+      </div>
+    </section>
+  )
+}
+
+export default ConsultationChat

--- a/src/components/ConsultationMailForm.tsx
+++ b/src/components/ConsultationMailForm.tsx
@@ -1,0 +1,102 @@
+import { useMemo, useState } from 'react'
+import type { FormEvent } from 'react'
+
+const DEFAULT_ACTION = 'https://formsubmit.co/jh2soft@naver.com'
+const MIN_MESSAGE_LENGTH = 20
+
+const resolveAction = () => {
+  const configured = import.meta.env.VITE_CONSULTATION_FORM_ACTION?.trim()
+  return configured && /^https?:\/\//i.test(configured) ? configured : DEFAULT_ACTION
+}
+
+const ConsultationMailForm = () => {
+  const action = useMemo(resolveAction, [])
+  const [submitting, setSubmitting] = useState(false)
+  const [helper, setHelper] = useState<string | null>(null)
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    const form = event.currentTarget
+    const formData = new FormData(form)
+    const message = (formData.get('message') as string | null) ?? ''
+
+    if (message.trim().length < MIN_MESSAGE_LENGTH) {
+      event.preventDefault()
+      setHelper(`문의 내용을 ${MIN_MESSAGE_LENGTH}자 이상 작성해주세요.`)
+      return
+    }
+
+    setHelper('메일을 전송 중입니다. 첫 제출 시 FormSubmit 인증 메일이 발송될 수 있어요.')
+    setSubmitting(true)
+
+    window.setTimeout(() => {
+      setSubmitting(false)
+      setHelper(null)
+    }, 5000)
+  }
+
+  return (
+    <section className="section consultation-mail" aria-labelledby="consultation-mail-heading">
+      <div className="consultation-mail-header">
+        <h2 id="consultation-mail-heading">문의 메일 보내기 (서버리스)</h2>
+        <p>FormSubmit을 활용해 별도 서버 없이도 상담 메일을 수신할 수 있습니다.</p>
+      </div>
+
+      <form
+        className="consultation-mail-form"
+        action={action}
+        method="POST"
+        onSubmit={handleSubmit}
+      >
+        <input type="hidden" name="_subject" value="[투자상담] 웹 문의" />
+        <input type="hidden" name="_captcha" value="false" />
+        <input type="hidden" name="_template" value="table" />
+        <input type="hidden" name="_next" value="" />
+
+        <div className="consultation-mail-row">
+          <label className="visually-hidden" htmlFor="consultation-mail-name">
+            이름
+          </label>
+          <input id="consultation-mail-name" name="name" placeholder="이름" required autoComplete="name" />
+          <label className="visually-hidden" htmlFor="consultation-mail-email">
+            이메일
+          </label>
+          <input
+            id="consultation-mail-email"
+            name="email"
+            type="email"
+            placeholder="이메일"
+            required
+            autoComplete="email"
+          />
+        </div>
+
+        <label className="visually-hidden" htmlFor="consultation-mail-subject">
+          제목
+        </label>
+        <input id="consultation-mail-subject" name="subject" placeholder="제목" required />
+
+        <label className="visually-hidden" htmlFor="consultation-mail-message">
+          문의 내용
+        </label>
+        <textarea
+          id="consultation-mail-message"
+          name="message"
+          placeholder="문의 내용을 자세히 작성해주세요 (20자 이상)"
+          required
+          minLength={MIN_MESSAGE_LENGTH}
+        />
+
+        <div className="consultation-mail-actions">
+          <button type="submit" className="consultation-mail-submit" disabled={submitting}>
+            {submitting ? '전송 중…' : '메일 보내기'}
+          </button>
+        </div>
+
+        <p className="consultation-mail-note">* 첫 제출 시 FormSubmit에서 본인 메일 인증 요청이 갈 수 있어요(스팸 방지).</p>
+        {helper && <p className="consultation-mail-helper">{helper}</p>}
+      </form>
+    </section>
+  )
+}
+
+export default ConsultationMailForm

--- a/src/types/webllm.d.ts
+++ b/src/types/webllm.d.ts
@@ -1,0 +1,47 @@
+export type WebLLMReport = {
+  text?: string
+  progress?: number
+}
+
+export type WebLLMChatMessage = {
+  role: string
+  content: string
+}
+
+export type WebLLMChatCompletionChunk = {
+  choices?: Array<{
+    delta?: {
+      content?: string
+    }
+  }>
+}
+
+export type WebLLMEngine = {
+  chat: {
+    completions: {
+      create: (input: {
+        messages: WebLLMChatMessage[]
+        temperature?: number
+        max_tokens?: number
+        stream?: boolean
+      }) => AsyncIterable<WebLLMChatCompletionChunk>
+    }
+  }
+  interruptGenerate?: () => void
+  dispose?: () => void
+}
+
+export type WebLLM = {
+  CreateMLCEngine: (
+    model: { model_id: string },
+    options?: { initProgressCallback?: (report: WebLLMReport) => void },
+  ) => Promise<WebLLMEngine>
+}
+
+declare global {
+  interface Window {
+    webllm?: WebLLM
+  }
+}
+
+export {}


### PR DESCRIPTION
## Summary
- embed the consultation chat and mail widgets directly on the landing page alongside the existing 상담 게시판
- add React components that wrap the WebLLM-powered Q&A experience and the FormSubmit mail form with matching dark theme styles
- define lightweight WebLLM types to load the CDN script safely in TypeScript

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4acc5c2448326a0a9870473403059