### PR TITLE
Update consultation copy and labels

### DIFF
--- a/public/consultation.html
+++ b/public/consultation.html
@@ -51,7 +51,7 @@
 
     <!-- 2) 투자상담 Q&A (브라우저 내 LLM: WebLLM) -->
     <section class="card" id="qa">
-      <h2>투자상담 · 질의응답 (서버/토큰 불필요)</h2>
+      <h2>투자상담 창구</h2>
       <div class="body">
         <div class="row">
           <input id="q" type="text" placeholder="질문을 입력하세요 (예: 이번 주 CPI 발표가 시장에 미칠 영향은?)" style="flex:1" />
@@ -62,15 +62,15 @@
         <div class="small muted mt8">
           <span class="pill">온디바이스 LLM</span>
           <span class="pill">Llama 3.2 1B-Instruct (Q4)</span>
-          <span class="pill">네트워크 없이 동작</span>
         </div>
       </div>
     </section>
 
     <!-- 3) 투자상담 메일 보내기 (FormSubmit 무료) -->
     <section class="card">
-      <h2>문의 메일 보내기 (서버리스)</h2>
+      <h2>문의 메일 보내기</h2>
       <div class="body">
+        <p class="muted">투자 전략부터 시장 전망까지 궁금한 점을 남겨주세요. JH 컨설턴트가 순차적으로 확인 후 직접 연락드립니다.</p>
         <!-- ✅ 아래 action 이메일만 본인 주소로 교체하세요 -->
         <form id="contact" action="https://formsubmit.co/jh2soft@naver.com" method="POST">
           <!-- FormSubmit 옵션 -->

--- a/src/components/ConsultationChat.tsx
+++ b/src/components/ConsultationChat.tsx
@@ -247,7 +247,7 @@ const ConsultationChat = () => {
   return (
     <section className="section consultation-ai" aria-labelledby="consultation-ai-heading">
       <div className="consultation-ai-header">
-        <h2 id="consultation-ai-heading">투자상담 · 질의응답 (서버/토큰 불필요)</h2>
+        <h2 id="consultation-ai-heading">투자상담 창구</h2>
         <p>
           브라우저에서 직접 실행되는 온디바이스 LLM으로 간단한 투자 Q&amp;A를 도와드립니다. 실시간 시세 등 최신 데이터가 필요한
           경우에는 별도로 안내해 드려요.
@@ -290,7 +290,6 @@ const ConsultationChat = () => {
       <div className="consultation-ai-meta">
         <span className="consultation-pill">온디바이스 LLM</span>
         <span className="consultation-pill">Llama 3.2 1B-Instruct (Q4)</span>
-        <span className="consultation-pill">네트워크 없이 동작</span>
       </div>
     </section>
   )

--- a/src/components/ConsultationMailForm.tsx
+++ b/src/components/ConsultationMailForm.tsx
@@ -37,8 +37,8 @@ const ConsultationMailForm = () => {
   return (
     <section className="section consultation-mail" aria-labelledby="consultation-mail-heading">
       <div className="consultation-mail-header">
-        <h2 id="consultation-mail-heading">문의 메일 보내기 (서버리스)</h2>
-        <p>FormSubmit을 활용해 별도 서버 없이도 상담 메일을 수신할 수 있습니다.</p>
+        <h2 id="consultation-mail-heading">문의 메일 보내기</h2>
+        <p>투자 전략부터 시장 전망까지 궁금한 점을 남겨주세요. JH 컨설턴트가 순차적으로 확인 후 직접 연락드립니다.</p>
       </div>
 
       <form


### PR DESCRIPTION
## Summary
- rename the consultation Q&A section to "투자상담 창구" across the app
- refresh the consultation mail call-to-action copy to highlight follow-up details
- remove the "네트워크 없이 동작" pill from the consultation UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4c29148388326affcce5d39f057a4