### PR TITLE
Adjust economic calendar widget

### DIFF
--- a/src/components/EconomicCalendar.tsx
+++ b/src/components/EconomicCalendar.tsx
@@ -60,9 +60,6 @@ const EconomicCalendar = () => {
 
       <div className="calendar-widget-panel">
         <h3 className="calendar-widget-title">Investing.com 미국 경제지표</h3>
-        <p className="calendar-widget-description">
-          전체 일정과 색상/언어 설정이 반영된 Investing.com 공식 위젯도 함께 확인해 보세요.
-        </p>
         <div className="calendar-widget-frame" role="region" aria-label="Investing.com 미국 경제지표 위젯">
           <iframe
             key={investingCalType}
@@ -70,7 +67,7 @@ const EconomicCalendar = () => {
             src={investingWidgetSrc}
             loading="lazy"
             width="100%"
-            height="600"
+            height="300"
             frameBorder={0}
           />
         </div>


### PR DESCRIPTION
## Summary
- remove the extra Investing.com widget description from the US economic calendar section
- reduce the widget iframe height to half (300px)

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4d4a3173c832685eabf1fca2e033c