### PR TITLE
Remove FormSubmit email verification note

### DIFF
--- a/public/consultation.html
+++ b/public/consultation.html
@@ -89,7 +89,6 @@
           <div class="row" style="justify-content:flex-end">
             <button class="primary" type="submit">메일 보내기</button>
           </div>
-          <p class="small muted mt8">* 첫 제출 시 FormSubmit에서 본인 메일 인증 요청이 갈 수 있어요(스팸 방지).</p>
         </form>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- remove the note about potential FormSubmit email verification in the consultation page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4d9ce8ed48326ba8e6776b9cffd0d