### PR TITLE
Update hero visuals and consultation mail header

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -77,11 +77,23 @@
   color: #f8fafc;
 }
 
-.hero-title-image {
+.hero-title-icon {
   width: clamp(72px, 12vw, 96px);
-  height: auto;
+  height: clamp(72px, 12vw, 96px);
   flex-shrink: 0;
-  filter: drop-shadow(0 12px 35px rgba(15, 23, 42, 0.55));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 24px;
+  background: radial-gradient(circle at 30% 20%, rgba(148, 163, 184, 0.25), rgba(15, 23, 42, 0));
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.55);
+  padding: 0.35rem;
+}
+
+.hero-title-icon svg {
+  width: 100%;
+  height: 100%;
 }
 
 .hero p {
@@ -269,6 +281,13 @@
   border-color: rgba(251, 191, 36, 0.28);
   box-shadow: 0 12px 28px rgba(251, 191, 36, 0.2);
   color: #facc15;
+}
+
+.section-title-icon.mail {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.25), rgba(14, 165, 233, 0.12));
+  border-color: rgba(56, 189, 248, 0.28);
+  box-shadow: 0 12px 28px rgba(14, 165, 233, 0.24);
+  color: #bae6fd;
 }
 
 .section-title-text {
@@ -1383,6 +1402,18 @@
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+}
+
+.consultation-mail-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.consultation-mail-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .consultation-ai-header h2,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,47 @@ import MarketOverview from './components/MarketOverview'
 import NewsFeed from './components/NewsFeed'
 import ConsultationMailForm from './components/ConsultationMailForm'
 
+const HeroIcon = () => (
+  <svg viewBox="0 0 96 96" role="img" aria-hidden="true" focusable="false">
+    <defs>
+      <linearGradient id="heroCyberGlow" x1="12" y1="8" x2="84" y2="88" gradientUnits="userSpaceOnUse">
+        <stop offset="0" stopColor="#38bdf8" stopOpacity="0.95" />
+        <stop offset="0.5" stopColor="#3b82f6" stopOpacity="0.85" />
+        <stop offset="1" stopColor="#6366f1" stopOpacity="0.9" />
+      </linearGradient>
+      <linearGradient id="heroLine" x1="16" y1="20" x2="78" y2="76" gradientUnits="userSpaceOnUse">
+        <stop offset="0" stopColor="#a5f3fc" />
+        <stop offset="1" stopColor="#c4b5fd" />
+      </linearGradient>
+    </defs>
+    <rect x="8" y="8" width="80" height="80" rx="22" fill="url(#heroCyberGlow)" opacity="0.92" />
+    <rect
+      x="14"
+      y="14"
+      width="68"
+      height="68"
+      rx="18"
+      fill="none"
+      stroke="rgba(148, 163, 184, 0.35)"
+      strokeWidth="1.6"
+      strokeDasharray="6 6"
+    />
+    <g stroke="url(#heroLine)" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" fill="none">
+      <path d="M26 60 40 46l11 8 19-20" />
+      <path d="M52 34h6v6" />
+    </g>
+    <g fill="#0f172a">
+      <rect x="26" y="52" width="6" height="14" rx="2" opacity="0.35" />
+      <rect x="38" y="42" width="6" height="24" rx="2" opacity="0.55" />
+      <rect x="50" y="48" width="6" height="18" rx="2" opacity="0.4" />
+      <rect x="62" y="34" width="6" height="32" rx="2" opacity="0.5" />
+    </g>
+    <circle cx="70" cy="28" r="6" fill="#22d3ee" opacity="0.85" />
+    <circle cx="26" cy="68" r="3" fill="#38bdf8" opacity="0.75" />
+    <circle cx="74" cy="64" r="3" fill="#818cf8" opacity="0.7" />
+  </svg>
+)
+
 function App() {
   return (
     <div className="app">
@@ -13,11 +54,9 @@ function App() {
           <div className="hero-main">
             <div className="hero-title">
               <h1>JH Investment Lab</h1>
-              <img
-                src="/expert-analyst.svg"
-                alt="투자 전문가 아이콘"
-                className="hero-title-image"
-              />
+              <span className="hero-title-icon" aria-hidden="true">
+                <HeroIcon />
+              </span>
             </div>
             <p>
               개인 투자자의 성공 투자를 위한 맞춤형 포탈 입니다. JH 컨설턴트와 상의하세요.(하단 링크)

--- a/src/components/ConsultationMailForm.tsx
+++ b/src/components/ConsultationMailForm.tsx
@@ -9,6 +9,15 @@ const resolveAction = () => {
   return configured && /^https?:\/\//i.test(configured) ? configured : DEFAULT_ACTION
 }
 
+const MailIcon = () => (
+  <svg viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+    <path
+      d="M4.5 5h15a1.5 1.5 0 0 1 1.5 1.5v11a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 17.5v-11A1.5 1.5 0 0 1 4.5 5zm.75 2.032v10.218h13.5V7.032l-6.343 4.196a1.5 1.5 0 0 1-1.614 0zm1.032-1.532 5.809 3.842a.5.5 0 0 0 .558 0L18.458 5.5z"
+      fill="currentColor"
+    />
+  </svg>
+)
+
 const ConsultationMailForm = () => {
   const action = useMemo(resolveAction, [])
   const [submitting, setSubmitting] = useState(false)
@@ -37,7 +46,14 @@ const ConsultationMailForm = () => {
   return (
     <section className="section consultation-mail" aria-labelledby="consultation-mail-heading">
       <div className="consultation-mail-header">
-        <h2 id="consultation-mail-heading">문의 메일 보내기</h2>
+        <div className="consultation-mail-title section-title">
+          <span className="section-title-icon mail" aria-hidden="true">
+            <MailIcon />
+          </span>
+          <div className="section-title-text">
+            <h2 id="consultation-mail-heading">문의 메일 보내기</h2>
+          </div>
+        </div>
         <p>투자 전략부터 시장 전망까지 궁금한 점을 남겨주세요. JH 컨설턴트가 순차적으로 확인 후 직접 연락드립니다.</p>
       </div>
 

--- a/src/components/EconomicCalendar.tsx
+++ b/src/components/EconomicCalendar.tsx
@@ -59,7 +59,6 @@ const EconomicCalendar = () => {
       </p>
 
       <div className="calendar-widget-panel">
-        <h3 className="calendar-widget-title">미국 경제지표</h3>
         <div className="calendar-widget-frame" role="region" aria-label="미국 경제지표 위젯">
           <iframe
             key={investingCalType}


### PR DESCRIPTION
## Summary
- replace the landing hero graphic with an inline cyber-styled stock icon to align with the rest of the UI
- add a dedicated icon beside the consultation mail heading for visual balance
- remove the redundant "미국 경제지표" caption that appeared above the embedded Investing.com widget

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4e4e10e288326a097e6a5b843eef5