### PR TITLE
feat: refresh hero icon with neon chart

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,41 +8,51 @@ import ConsultationMailForm from './components/ConsultationMailForm'
 const HeroIcon = () => (
   <svg viewBox="0 0 96 96" role="img" aria-hidden="true" focusable="false">
     <defs>
-      <linearGradient id="heroCyberGlow" x1="12" y1="8" x2="84" y2="88" gradientUnits="userSpaceOnUse">
-        <stop offset="0" stopColor="#38bdf8" stopOpacity="0.95" />
-        <stop offset="0.5" stopColor="#3b82f6" stopOpacity="0.85" />
-        <stop offset="1" stopColor="#6366f1" stopOpacity="0.9" />
+      <linearGradient id="heroNeonBase" x1="18" y1="12" x2="78" y2="84" gradientUnits="userSpaceOnUse">
+        <stop offset="0" stopColor="#052e16" />
+        <stop offset="1" stopColor="#04130f" />
       </linearGradient>
-      <linearGradient id="heroLine" x1="16" y1="20" x2="78" y2="76" gradientUnits="userSpaceOnUse">
-        <stop offset="0" stopColor="#a5f3fc" />
-        <stop offset="1" stopColor="#c4b5fd" />
+      <radialGradient id="heroNeonGlow" cx="48" cy="48" r="42" gradientUnits="userSpaceOnUse">
+        <stop offset="0.1" stopColor="#82ffb5" stopOpacity="0.25" />
+        <stop offset="0.55" stopColor="#2af598" stopOpacity="0.1" />
+        <stop offset="1" stopColor="#0f172a" stopOpacity="0" />
+      </radialGradient>
+      <linearGradient id="heroNeonLine" x1="24" y1="64" x2="74" y2="28" gradientUnits="userSpaceOnUse">
+        <stop offset="0" stopColor="#7dff7a" />
+        <stop offset="0.45" stopColor="#72ffa8" />
+        <stop offset="1" stopColor="#4cffd0" />
+      </linearGradient>
+      <linearGradient id="heroNeonBars" x1="28" y1="34" x2="68" y2="70" gradientUnits="userSpaceOnUse">
+        <stop offset="0" stopColor="#16f08b" stopOpacity="0.35" />
+        <stop offset="1" stopColor="#6dffb5" stopOpacity="0.7" />
       </linearGradient>
     </defs>
-    <rect x="8" y="8" width="80" height="80" rx="22" fill="url(#heroCyberGlow)" opacity="0.92" />
+    <rect x="10" y="10" width="76" height="76" rx="20" fill="#030712" />
+    <rect x="14" y="14" width="68" height="68" rx="18" fill="url(#heroNeonBase)" />
+    <rect x="14" y="14" width="68" height="68" rx="18" fill="url(#heroNeonGlow)" />
     <rect
-      x="14"
-      y="14"
-      width="68"
-      height="68"
-      rx="18"
+      x="20"
+      y="20"
+      width="56"
+      height="56"
+      rx="14"
       fill="none"
-      stroke="rgba(148, 163, 184, 0.35)"
-      strokeWidth="1.6"
-      strokeDasharray="6 6"
+      stroke="rgba(148, 255, 193, 0.25)"
+      strokeWidth="1.4"
     />
-    <g stroke="url(#heroLine)" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" fill="none">
-      <path d="M26 60 40 46l11 8 19-20" />
-      <path d="M52 34h6v6" />
+    <g fill="none" strokeLinecap="round" strokeLinejoin="round">
+      <path
+        d="M26 58 36 48l10 8 12-16 12 6"
+        stroke="url(#heroNeonLine)"
+        strokeWidth="3"
+      />
+      <path d="M30 60v8" stroke="url(#heroNeonBars)" strokeWidth="3.2" />
+      <path d="M42 54v14" stroke="url(#heroNeonBars)" strokeWidth="3.2" />
+      <path d="M54 44v24" stroke="url(#heroNeonBars)" strokeWidth="3.2" />
+      <path d="M66 40v28" stroke="url(#heroNeonBars)" strokeWidth="3.2" />
     </g>
-    <g fill="#0f172a">
-      <rect x="26" y="52" width="6" height="14" rx="2" opacity="0.35" />
-      <rect x="38" y="42" width="6" height="24" rx="2" opacity="0.55" />
-      <rect x="50" y="48" width="6" height="18" rx="2" opacity="0.4" />
-      <rect x="62" y="34" width="6" height="32" rx="2" opacity="0.5" />
-    </g>
-    <circle cx="70" cy="28" r="6" fill="#22d3ee" opacity="0.85" />
-    <circle cx="26" cy="68" r="3" fill="#38bdf8" opacity="0.75" />
-    <circle cx="74" cy="64" r="3" fill="#818cf8" opacity="0.7" />
+    <circle cx="68" cy="36" r="5" fill="#b5ff8a" opacity="0.85" />
+    <circle cx="30" cy="68" r="3" fill="#6bff95" opacity="0.8" />
   </svg>
 )
 


### PR DESCRIPTION
## Summary
- restyle the hero chart icon with a simplified neon green palette and subtle glow
- keep the chart motif while introducing bar and line accents for a cleaner look

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4e9a86d248326862d153ae6acf716