### PR TITLE
Use local proxy for Yahoo commodity quotes

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,11 @@ export default defineConfig({
         changeOrigin: true,
         secure: false,
       },
+      '/api/quotes': {
+        target: 'http://localhost:4174',
+        changeOrigin: true,
+        secure: false,
+      },
     },
   },
 })


### PR DESCRIPTION
## Summary
- rely on the existing Express /api/quotes proxy for Yahoo Finance commodity and FX data instead of third-party fallbacks
- proxy the /api/quotes route through the Vite dev server for local development

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9e9efcc788326a202eab52d0bd838